### PR TITLE
Add authentication hooks and S3 client with ETag caching

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,4 +1,6 @@
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
+import { useEffect } from 'react';
+import { useAuth } from './state/useAuth';
 import { ThemeButton } from './components/ThemeButton';
 import CalendarPage from './pages/CalendarPage';
 import DatePage from './pages/DatePage';
@@ -23,6 +25,18 @@ function Layout() {
 }
 
 export default function App() {
+  const { status, login } = useAuth();
+
+  useEffect(() => {
+    if (status === 'unauthenticated') {
+      login();
+    }
+  }, [status, login]);
+
+  if (status !== 'authenticated') {
+    return null;
+  }
+
   return (
     <BrowserRouter>
       <Layout />

--- a/web/src/lib/etagCache.ts
+++ b/web/src/lib/etagCache.ts
@@ -1,0 +1,20 @@
+import { openDB } from 'idb';
+
+const dbPromise = openDB('etag-cache', 1, {
+  upgrade(db) {
+    db.createObjectStore('etags');
+  },
+});
+
+export async function getEtag(key: string): Promise<string | undefined> {
+  return (await dbPromise).get('etags', key);
+}
+
+export async function setEtag(key: string, etag: string): Promise<void> {
+  await (await dbPromise).put('etags', etag, key);
+}
+
+export async function clearEtag(key: string): Promise<void> {
+  await (await dbPromise).delete('etags', key);
+}
+

--- a/web/src/lib/s3Client.ts
+++ b/web/src/lib/s3Client.ts
@@ -1,0 +1,75 @@
+import {
+  S3Client,
+  GetObjectCommand,
+  PutObjectCommand,
+  ListObjectsV2Command,
+} from '@aws-sdk/client-s3';
+import { useAuth } from '../state/useAuth';
+import { getEtag, setEtag } from './etagCache';
+
+const region = import.meta.env.VITE_REGION as string;
+const bucket = import.meta.env.VITE_ENTRY_BUCKET as string;
+
+function getClient() {
+  const creds = useAuth.getState().credentialProvider;
+  if (!creds) {
+    throw new Error('Not authenticated');
+  }
+  return new S3Client({ region, credentials: creds });
+}
+
+function entryKey(ymd: string) {
+  const prefix = useAuth.getState().userPrefix ?? '';
+  return `${prefix}/${ymd}.json`;
+}
+
+export async function getEntry(ymd: string): Promise<string | null> {
+  const client = getClient();
+  const key = entryKey(ymd);
+  const etag = await getEtag(key);
+  try {
+    const res = await client.send(
+      new GetObjectCommand({ Bucket: bucket, Key: key, IfNoneMatch: etag })
+    );
+    const body = await new Response(res.Body as ReadableStream).text();
+    if (res.ETag) await setEtag(key, res.ETag);
+    return body;
+  } catch (err) {
+    const status = (err as { $metadata?: { httpStatusCode?: number } }).$metadata?.httpStatusCode;
+    if (status === 304) {
+      return null;
+    }
+    if (status === 404) {
+      return null;
+    }
+    throw err;
+  }
+}
+
+export async function putEntry(ymd: string, body: string): Promise<void> {
+  const client = getClient();
+  const key = entryKey(ymd);
+  const res = await client.send(
+    new PutObjectCommand({
+      Bucket: bucket,
+      Key: key,
+      Body: body,
+      ContentType: 'application/json',
+    })
+  );
+  if (res.ETag) await setEtag(key, res.ETag);
+}
+
+export async function listMonth(yyyy: string, mm: string): Promise<string[]> {
+  const client = getClient();
+  const prefix = `${useAuth.getState().userPrefix ?? ''}/${yyyy}-${mm}`;
+  const res = await client.send(
+    new ListObjectsV2Command({ Bucket: bucket, Prefix: prefix })
+  );
+  return (
+    res.Contents?.map((obj) => obj.Key || '')
+      .filter((k) => k)
+      .map((k) => k.slice(prefix.length + 1).replace(/\.json$/, '')) ?? []
+  );
+}
+

--- a/web/src/state/useAuth.ts
+++ b/web/src/state/useAuth.ts
@@ -1,0 +1,83 @@
+import { create } from 'zustand';
+import { fromCognitoIdentityPool } from '@aws-sdk/credential-provider-cognito-identity';
+
+interface AuthState {
+  /** current authentication status */
+  status: 'loading' | 'authenticated' | 'unauthenticated';
+  /** AWS credential provider once authenticated */
+  credentialProvider?: ReturnType<typeof fromCognitoIdentityPool>;
+  /** per-user prefix derived from the id token */
+  userPrefix?: string;
+  /** redirect the browser to the Cognito Hosted UI */
+  login: () => void;
+  /** clear stored tokens and re-authenticate */
+  logout: () => void;
+}
+
+const region = import.meta.env.VITE_REGION as string;
+const userPoolId = import.meta.env.VITE_USER_POOL_ID as string;
+const clientId = import.meta.env.VITE_USER_POOL_CLIENT_ID as string;
+const identityPoolId = import.meta.env.VITE_IDENTITY_POOL_ID as string;
+const hostedUiDomain = import.meta.env.VITE_HOSTED_UI_DOMAIN as string;
+
+function decodeJwt<T extends Record<string, unknown>>(token: string): T {
+  const payload = token.split('.')[1];
+  const json = atob(payload.replace(/-/g, '+').replace(/_/g, '/'));
+  return JSON.parse(json) as T;
+}
+
+const redirectUri = typeof window !== 'undefined' ? window.location.origin : '';
+
+export const useAuth = create<AuthState>((set) => ({
+  status: 'loading',
+  login: () => {
+    const url =
+      `https://${hostedUiDomain}/login?` +
+      `client_id=${clientId}&response_type=token&scope=openid+profile&redirect_uri=${encodeURIComponent(redirectUri)}`;
+    window.location.assign(url);
+  },
+  logout: () => {
+    localStorage.removeItem('idToken');
+    set({ status: 'unauthenticated', credentialProvider: undefined, userPrefix: undefined });
+    const url =
+      `https://${hostedUiDomain}/logout?` +
+      `client_id=${clientId}&logout_uri=${encodeURIComponent(redirectUri)}`;
+    window.location.assign(url);
+  },
+}));
+
+async function init() {
+  const hash = new URLSearchParams(window.location.hash.substring(1));
+  const idTokenFromHash = hash.get('id_token');
+  if (idTokenFromHash) {
+    localStorage.setItem('idToken', idTokenFromHash);
+    window.location.hash = '';
+  }
+  const idToken = localStorage.getItem('idToken');
+  if (!idToken) {
+    useAuth.setState({ status: 'unauthenticated' });
+    return;
+  }
+
+  const loginKey = `cognito-idp.${region}.amazonaws.com/${userPoolId}`;
+  const credentialProvider = fromCognitoIdentityPool({
+    identityPoolId,
+    clientConfig: { region },
+    logins: { [loginKey]: idToken },
+  });
+
+  const payload = decodeJwt<{ sub: string }>(idToken);
+  const userPrefix = payload.sub;
+
+  useAuth.setState({
+    status: 'authenticated',
+    credentialProvider,
+    userPrefix,
+  });
+}
+
+if (typeof window !== 'undefined') {
+  // kick off initialization on first import
+  init().catch(() => useAuth.setState({ status: 'unauthenticated' }));
+}
+


### PR DESCRIPTION
## Summary
- add `useAuth` hook using AWS Cognito Hosted UI and identity pool credentials
- implement IndexedDB-backed ETag cache and S3 helpers for diary entry access
- wire auth into `App` to redirect unauthenticated users to Hosted UI

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bd2d38bfb8832bb4231a025eef1ac3