### PR TITLE
feat: add calendar grid and navigation

### DIFF
--- a/web/src/components/CalendarGrid.tsx
+++ b/web/src/components/CalendarGrid.tsx
@@ -1,0 +1,54 @@
+import { useMemo } from 'react';
+
+interface CalendarGridProps {
+  year: number;
+  month: number; // 1-based month
+  entries: string[]; // array of days like '01', '02'
+  today?: string; // 'YYYY-MM-DD'
+  onSelect?: (ymd: string) => void;
+}
+
+function pad(n: number) {
+  return n.toString().padStart(2, '0');
+}
+
+export function CalendarGrid({ year, month, entries, today, onSelect }: CalendarGridProps) {
+  const cells = useMemo(() => {
+    const firstDay = new Date(year, month - 1, 1);
+    const start = firstDay.getDay();
+    const daysInMonth = new Date(year, month, 0).getDate();
+    const arr: (number | null)[] = [];
+    for (let i = 0; i < start; i++) arr.push(null);
+    for (let d = 1; d <= daysInMonth; d++) arr.push(d);
+    while (arr.length % 7 !== 0) arr.push(null);
+    return arr;
+  }, [year, month]);
+
+  const monthStr = pad(month);
+
+  return (
+    <div className="grid grid-cols-7 gap-2">
+      {cells.map((day, idx) => {
+        if (!day) {
+          return <div key={idx} />;
+        }
+        const dayStr = pad(day);
+        const ymd = `${year}-${monthStr}-${dayStr}`;
+        const isToday = today === ymd;
+        const hasEntry = entries.includes(dayStr);
+        return (
+          <button
+            key={idx}
+            onClick={() => onSelect?.(ymd)}
+            className={`flex h-14 flex-col items-center justify-center rounded hover:bg-gray-200 dark:hover:bg-gray-700 ${
+              isToday ? 'bg-blue-200 dark:bg-blue-800' : ''
+            }`}
+          >
+            <span>{day}</span>
+            {hasEntry && <span className="mt-1 h-1 w-1 rounded-full bg-blue-500" />}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/web/src/pages/CalendarPage.tsx
+++ b/web/src/pages/CalendarPage.tsx
@@ -1,3 +1,35 @@
+import { useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { CalendarGrid } from '../components/CalendarGrid';
+import { listMonth } from '../lib/s3Client';
+
+function pad(n: number) {
+  return n.toString().padStart(2, '0');
+}
+
 export default function CalendarPage() {
-  return <div>Calendar placeholder</div>;
+  const { yyyy, mm } = useParams<{ yyyy?: string; mm?: string }>();
+  const today = new Date();
+  const year = yyyy ? parseInt(yyyy, 10) : today.getFullYear();
+  const month = mm ? parseInt(mm, 10) : today.getMonth() + 1;
+  const [entries, setEntries] = useState<string[]>([]);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    listMonth(String(year), pad(month)).then(setEntries).catch(() => setEntries([]));
+  }, [year, month]);
+
+  const todayYmd = `${today.getFullYear()}-${pad(today.getMonth() + 1)}-${pad(today.getDate())}`;
+
+  return (
+    <div className="paper-page p-4">
+      <CalendarGrid
+        year={year}
+        month={month}
+        entries={entries}
+        today={todayYmd}
+        onSelect={(ymd) => navigate(`/date/${ymd}`)}
+      />
+    </div>
+  );
 }

--- a/web/src/pages/DatePage.tsx
+++ b/web/src/pages/DatePage.tsx
@@ -1,3 +1,37 @@
+import { useNavigate, useParams } from 'react-router-dom';
+
+function formatYmd(d: Date) {
+  const pad = (n: number) => n.toString().padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+}
+
 export default function DatePage() {
-  return <div className="paper-page p-4">Day page placeholder</div>;
+  const { ymd } = useParams<{ ymd: string }>();
+  const navigate = useNavigate();
+
+  const today = new Date();
+  const todayYmd = formatYmd(today);
+  const current = ymd ? new Date(ymd) : today;
+
+  const handleNext = () => {
+    if (ymd && ymd !== todayYmd) {
+      navigate(`/date/${todayYmd}`);
+    } else {
+      const next = new Date(current);
+      next.setDate(current.getDate() + 1);
+      navigate(`/date/${formatYmd(next)}`);
+    }
+  };
+
+  return (
+    <div className="paper-page p-4">
+      <div className="mb-4">Day page placeholder for {ymd}</div>
+      <button
+        className="rounded bg-blue-500 px-2 py-1 text-white"
+        onClick={handleNext}
+      >
+        Next
+      </button>
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
- add reusable CalendarGrid component with entry markers and today highlight
- render monthly calendar using listMonth and CalendarGrid
- support Next navigation that returns to today or advances to tomorrow

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bd2ef62358832b916809edab6b7f00