### PR TITLE
feat: day page with routines and weather

### DIFF
--- a/web/src/components/Attachments.tsx
+++ b/web/src/components/Attachments.tsx
@@ -1,0 +1,40 @@
+interface AttachmentsProps {
+  files: File[];
+  onChange: (files: File[]) => void;
+}
+
+export function Attachments({ files, onChange }: AttachmentsProps) {
+  const handleSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const list = e.target.files ? Array.from(e.target.files) : [];
+    onChange([...files, ...list]);
+    e.target.value = '';
+  };
+
+  const remove = (idx: number) => {
+    const next = [...files];
+    next.splice(idx, 1);
+    onChange(next);
+  };
+
+  return (
+    <div className="mt-2">
+      <input type="file" multiple onChange={handleSelect} />
+      {files.length > 0 && (
+        <ul className="mt-2 list-disc pl-4 text-sm">
+          {files.map((f, idx) => (
+            <li key={idx}>
+              {f.name}
+              <button
+                type="button"
+                onClick={() => remove(idx)}
+                className="ml-2 text-red-600"
+              >
+                remove
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/InkGauge.tsx
+++ b/web/src/components/InkGauge.tsx
@@ -1,0 +1,16 @@
+interface InkGaugeProps {
+  used: number;
+  total: number;
+}
+
+export function InkGauge({ used, total }: InkGaugeProps) {
+  const percent = total > 0 ? Math.min(100, (used / total) * 100) : 0;
+  return (
+    <div className="h-2 w-full rounded bg-gray-300 dark:bg-gray-700">
+      <div
+        className="h-full rounded bg-blue-500"
+        style={{ width: `${percent}%` }}
+      />
+    </div>
+  );
+}

--- a/web/src/components/RoutineBar.tsx
+++ b/web/src/components/RoutineBar.tsx
@@ -1,0 +1,65 @@
+import { useEffect, useState } from 'react';
+
+export interface RoutineItem {
+  text: string;
+  done: boolean;
+}
+
+interface RoutineBarProps {
+  items: RoutineItem[];
+  onChange?: (items: RoutineItem[]) => void;
+}
+
+export function RoutineBar({ items, onChange }: RoutineBarProps) {
+  const [local, setLocal] = useState<RoutineItem[]>(items);
+
+  useEffect(() => setLocal(items), [items]);
+
+  const update = (next: RoutineItem[]) => {
+    setLocal(next);
+    onChange?.(next);
+  };
+
+  const toggle = (idx: number) => {
+    const next = [...local];
+    next[idx].done = !next[idx].done;
+    update(next);
+  };
+
+  const changeText = (idx: number, text: string) => {
+    const next = [...local];
+    next[idx].text = text;
+    update(next);
+  };
+
+  const addItem = () => {
+    update([...local, { text: '', done: false }]);
+  };
+
+  return (
+    <div className="mb-2 flex flex-wrap gap-2">
+      {local.map((item, idx) => (
+        <label key={idx} className="flex items-center gap-1">
+          <input
+            type="checkbox"
+            checked={item.done}
+            onChange={() => toggle(idx)}
+          />
+          <input
+            className="border-b bg-transparent outline-none"
+            value={item.text}
+            onChange={(e) => changeText(idx, e.target.value)}
+            placeholder={`Task ${idx + 1}`}
+          />
+        </label>
+      ))}
+      <button
+        type="button"
+        onClick={addItem}
+        className="rounded bg-gray-200 px-2 py-1 text-sm dark:bg-gray-700"
+      >
+        +
+      </button>
+    </div>
+  );
+}

--- a/web/src/lib/date.ts
+++ b/web/src/lib/date.ts
@@ -1,0 +1,25 @@
+export function pad(n: number): string {
+  return n.toString().padStart(2, '0');
+}
+
+/** Format a Date into YYYY-MM-DD */
+export function formatYmd(d: Date): string {
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+}
+
+/** Parse a YYYY-MM-DD string into a Date object */
+export function parseYmd(ymd: string): Date {
+  const [y, m, day] = ymd.split('-').map((s) => parseInt(s, 10));
+  return new Date(y, m - 1, day);
+}
+
+/** Human friendly date like 'Monday, January 1, 2024' */
+export function displayDate(ymd: string): string {
+  const d = parseYmd(ymd);
+  return d.toLocaleDateString(undefined, {
+    weekday: 'long',
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+}

--- a/web/src/pages/DatePage.tsx
+++ b/web/src/pages/DatePage.tsx
@@ -1,9 +1,16 @@
 import { useNavigate, useParams } from 'react-router-dom';
-
-function formatYmd(d: Date) {
-  const pad = (n: number) => n.toString().padStart(2, '0');
-  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
-}
+import { useCallback, useState } from 'react';
+import { displayDate, formatYmd, parseYmd } from '../lib/date';
+import {
+  getDailyWeather,
+  getLocation,
+  reverseGeocode,
+  type Location,
+  type Weather,
+} from '../lib/weather';
+import { InkGauge } from '../components/InkGauge';
+import { RoutineBar, type RoutineItem } from '../components/RoutineBar';
+import { Attachments } from '../components/Attachments';
 
 export default function DatePage() {
   const { ymd } = useParams<{ ymd: string }>();
@@ -11,7 +18,15 @@ export default function DatePage() {
 
   const today = new Date();
   const todayYmd = formatYmd(today);
-  const current = ymd ? new Date(ymd) : today;
+  const current = ymd ? parseYmd(ymd) : today;
+  const ymdStr = ymd || todayYmd;
+
+  const [text, setText] = useState('');
+  const [routines, setRoutines] = useState<RoutineItem[]>([]);
+  const [files, setFiles] = useState<File[]>([]);
+  const [location, setLocation] = useState<Location | null>(null);
+  const [weather, setWeather] = useState<Weather | null>(null);
+  const [fetched, setFetched] = useState(false);
 
   const handleNext = () => {
     if (ymd && ymd !== todayYmd) {
@@ -23,11 +38,89 @@ export default function DatePage() {
     }
   };
 
+  const fetchMeta = useCallback(async () => {
+    const loc = await getLocation();
+    if (!loc) return;
+    const city = await reverseGeocode(loc.lat, loc.lon);
+    const w = await getDailyWeather(loc.lat, loc.lon, ymdStr);
+    setLocation({ ...loc, city });
+    if (w) setWeather(w);
+  }, [ymdStr]);
+
+  const handleMainChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const mainVal = e.target.value;
+    const over = text.split('\n').slice(28).join('\n');
+    const newText = over ? `${mainVal}\n${over}` : mainVal;
+    setText(newText);
+    if (!fetched && newText.trim() !== '') {
+      setFetched(true);
+      fetchMeta();
+    }
+  };
+
+  const handleOverflowChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const overVal = e.target.value;
+    const mainPart = text.split('\n').slice(0, 28).join('\n');
+    const newText = overVal ? `${mainPart}\n${overVal}` : mainPart;
+    setText(newText);
+    if (!fetched && newText.trim() !== '') {
+      setFetched(true);
+      fetchMeta();
+    }
+  };
+
+  const lines = text.split('\n');
+  const mainText = lines.slice(0, 28).join('\n');
+  const overflowText = lines.length > 28 ? lines.slice(28).join('\n') : '';
+
   return (
     <div className="paper-page p-4">
-      <div className="mb-4">Day page placeholder for {ymd}</div>
+      <header className="mb-4">
+        <div className="text-xl font-bold">{displayDate(ymdStr)}</div>
+        <div className="flex items-center gap-2 text-sm">
+          {location?.city && <span>{location.city}</span>}
+          {weather && (
+            <span>
+              {weather.desc} {weather.tmin}–{weather.tmax}°C
+            </span>
+          )}
+          <button
+            className="text-xs underline"
+            onClick={fetchMeta}
+            type="button"
+          >
+            Refresh
+          </button>
+        </div>
+      </header>
+
+      <RoutineBar items={routines} onChange={setRoutines} />
+
+      <textarea
+        rows={28}
+        className="w-full resize-none bg-transparent outline-none"
+        value={mainText}
+        onChange={handleMainChange}
+      />
+
+      <details className="mt-2" open={Boolean(overflowText)}>
+        <summary>Overflow</summary>
+        <textarea
+          className="mt-2 w-full resize-none bg-transparent outline-none"
+          value={overflowText}
+          onChange={handleOverflowChange}
+          rows={Math.max(overflowText.split('\n').length, 1)}
+        />
+      </details>
+
+      <div className="my-2">
+        <InkGauge used={Math.min(lines.length, 28)} total={28} />
+      </div>
+
+      <Attachments files={files} onChange={setFiles} />
+
       <button
-        className="rounded bg-blue-500 px-2 py-1 text-white"
+        className="mt-4 rounded bg-blue-500 px-2 py-1 text-white"
         onClick={handleNext}
       >
         Next


### PR DESCRIPTION
## Summary
- add date helper utilities
- implement ink gauge, routine bar, and attachment components
- enhance day page with weather, location, routines, overflow drawer, and ink gauge

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bd2ffe9f00832baa395eba151f1cdc