### PR TITLE
Preload handwriting font and scope paper theme font

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -7,6 +7,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="preload" href="https://fonts.gstatic.com/s/patrickhand/v25/LDI1apSQOAYtSuYWp8ZhfYe8XsLL.woff2" as="font" type="font/woff2" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Patrick+Hand&display=swap" rel="stylesheet">
     <title>AutoDiary</title>
   </head>

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -18,6 +18,9 @@ html[data-theme='paper'] {
   --bg: #f8f5e4;
   --text: #111111;
   --paper: #f8f5e4;
+}
+
+html[data-theme='paper'] .paper-page {
   font-family: 'Patrick Hand', cursive;
 }
 


### PR DESCRIPTION
## Summary
- limit paper theme's handwriting font to elements with `paper-page` class
- preload the Patrick Hand font to avoid layout shifts when switching themes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bd348b2260832b9b633b7bb2a9dfdc