### PR TITLE
feat: add manual weather lookup and caching

### DIFF
--- a/web/src/lib/weather.ts
+++ b/web/src/lib/weather.ts
@@ -10,17 +10,33 @@ export interface Weather {
   desc: string;
 }
 
+async function forwardGeocode(city: string): Promise<Location | null> {
+  const url = `https://geocoding-api.open-meteo.com/v1/search?name=${encodeURIComponent(
+    city
+  )}&language=en&count=1`;
+  const res = await fetch(url);
+  const data = await res.json();
+  const r = data?.results?.[0];
+  return r ? { lat: r.latitude, lon: r.longitude, city: r.name } : null;
+}
+
 export async function getLocation(): Promise<Location | null> {
-  if (!('geolocation' in navigator)) return null;
-  return new Promise((resolve) => {
-    navigator.geolocation.getCurrentPosition(
-      (pos) => {
-        resolve({ lat: pos.coords.latitude, lon: pos.coords.longitude });
-      },
-      () => resolve(null),
-      { timeout: 10000 }
-    );
-  });
+  if ('geolocation' in navigator) {
+    try {
+      const pos = await new Promise<GeolocationPosition>((resolve, reject) => {
+        navigator.geolocation.getCurrentPosition(resolve, reject, {
+          timeout: 10000,
+        });
+      });
+      return { lat: pos.coords.latitude, lon: pos.coords.longitude };
+    } catch {
+      /* fall through to manual input */
+    }
+  }
+
+  const city = window.prompt('Enter your city');
+  if (!city) return null;
+  return await forwardGeocode(city);
 }
 
 export async function reverseGeocode(lat: number, lon: number): Promise<string | undefined> {
@@ -46,4 +62,20 @@ export async function getDailyWeather(lat: number, lon: number, date: string): P
     tmin: data.daily.temperature_2m_min?.[0],
     desc: codeMap[code] || 'Unknown',
   };
+}
+
+export async function refreshWeather(
+  entry: Record<string, unknown>,
+  date: string
+): Promise<{ location: Location; weather: Weather } | null> {
+  const loc = await getLocation();
+  if (!loc) return null;
+  const city = loc.city ?? (await reverseGeocode(loc.lat, loc.lon));
+  const weather = await getDailyWeather(loc.lat, loc.lon, date);
+  if (!weather) return null;
+  if (city) entry.city = city;
+  entry.tmax = weather.tmax;
+  entry.tmin = weather.tmin;
+  entry.desc = weather.desc;
+  return { location: { ...loc, city }, weather };
 }


### PR DESCRIPTION
## Summary
- allow manual city input with forward geocoding when browser geolocation fails
- cache weather details on an entry and provide `refreshWeather` to refresh them
- load cached weather in DatePage and support manual refresh

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bd3540f3f8832b91e99e377aed5436