### PR TITLE
Use ETag for optimistic S3 PUT

### DIFF
--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -42,7 +42,26 @@ export default function SettingsPage() {
       await putSettings(data);
       alert('Settings saved');
     } catch (err) {
-      console.error('Failed to save settings', err);
+      const status = (err as { $metadata?: { httpStatusCode?: number } }).$metadata
+        ?.httpStatusCode;
+      if (status === 412) {
+        const latest = await getSettings();
+        const diff = `Server:\n${JSON.stringify(
+          latest,
+          null,
+          2
+        )}\n\nYours:\n${JSON.stringify(data, null, 2)}`;
+        if (
+          confirm(
+            `Settings have changed on the server. Overwrite with your changes?\n\n${diff}`
+          )
+        ) {
+          await putSettings(data);
+          alert('Settings saved');
+        }
+      } else {
+        console.error('Failed to save settings', err);
+      }
     }
   };
 


### PR DESCRIPTION
## Summary
- retrieve cached ETags before PUTs and send IfMatch headers
- clear ETag cache and bubble up 412 conflicts
- prompt to resolve settings conflicts with diff when 412 occurs

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bd3cf72a90832b87ebe03eeee7e06a