### PR TITLE
Hydrate and sync diary entries

### DIFF
--- a/web/src/components/Attachments.tsx
+++ b/web/src/components/Attachments.tsx
@@ -1,32 +1,62 @@
-interface AttachmentsProps {
-  files: File[];
-  onChange: (files: File[]) => void;
+interface AttachmentMeta {
+  name: string;
+  uuid: string;
 }
 
-export function Attachments({ files, onChange }: AttachmentsProps) {
+interface AttachmentsProps {
+  files: File[];
+  existing: AttachmentMeta[];
+  onFilesChange: (files: File[]) => void;
+  onExistingChange: (items: AttachmentMeta[]) => void;
+}
+
+export function Attachments({
+  files,
+  existing,
+  onFilesChange,
+  onExistingChange,
+}: AttachmentsProps) {
   const handleSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
     const list = e.target.files ? Array.from(e.target.files) : [];
-    onChange([...files, ...list]);
+    onFilesChange([...files, ...list]);
     e.target.value = '';
   };
 
-  const remove = (idx: number) => {
+  const removeFile = (idx: number) => {
     const next = [...files];
     next.splice(idx, 1);
-    onChange(next);
+    onFilesChange(next);
+  };
+
+  const removeExisting = (idx: number) => {
+    const next = [...existing];
+    next.splice(idx, 1);
+    onExistingChange(next);
   };
 
   return (
     <div className="mt-2">
       <input type="file" multiple onChange={handleSelect} />
-      {files.length > 0 && (
+      {(existing.length > 0 || files.length > 0) && (
         <ul className="mt-2 list-disc pl-4 text-sm">
-          {files.map((f, idx) => (
-            <li key={idx}>
+          {existing.map((f, idx) => (
+            <li key={f.uuid}>
               {f.name}
               <button
                 type="button"
-                onClick={() => remove(idx)}
+                onClick={() => removeExisting(idx)}
+                className="ml-2 text-red-600"
+              >
+                remove
+              </button>
+            </li>
+          ))}
+          {files.map((f, idx) => (
+            <li key={`new-${idx}`}>
+              {f.name}
+              <button
+                type="button"
+                onClick={() => removeFile(idx)}
                 className="ml-2 text-red-600"
               >
                 remove

--- a/web/src/lib/s3Client.ts
+++ b/web/src/lib/s3Client.ts
@@ -40,6 +40,23 @@ export function attachmentKey(ymd: string, uuid: string) {
   return `${prefix}/attachments/${yyyy}/${mm}/${dd}/${uuid}`;
 }
 
+export async function putAttachment(
+  ymd: string,
+  uuid: string,
+  file: File
+): Promise<void> {
+  const client = getClient();
+  const key = attachmentKey(ymd, uuid);
+  await client.send(
+    new PutObjectCommand({
+      Bucket: bucket,
+      Key: key,
+      Body: file,
+      ContentType: file.type,
+    })
+  );
+}
+
 export interface Settings {
   theme: 'light' | 'dark' | 'paper';
   routineTemplate: { text: string; done: boolean }[];

--- a/web/src/service-worker.ts
+++ b/web/src/service-worker.ts
@@ -84,7 +84,13 @@ self.addEventListener('fetch', (event) => {
 self.addEventListener('sync', (event) => {
   const syncEvent = event as SyncEvent;
   if (syncEvent.tag === 's3-sync') {
-    syncEvent.waitUntil(replayQueue());
+    syncEvent.waitUntil(
+      (async () => {
+        await replayQueue();
+        const clients = await self.clients.matchAll();
+        clients.forEach((c) => c.postMessage({ type: 's3-sync-complete' }));
+      })()
+    );
   }
 });
 


### PR DESCRIPTION
## Summary
- load saved entry data on Date page using `getEntry`
- save updates with `putEntry` and upload attachments, debounced and on navigation
- notify client after service worker offline PUT queue syncs to refresh display

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bd3e265acc832bb2fe984b2ef5fd13