### PR TITLE
feat: track routine ticks per entry

### DIFF
--- a/web/src/components/RoutineBar.tsx
+++ b/web/src/components/RoutineBar.tsx
@@ -8,9 +8,10 @@ export interface RoutineItem {
 interface RoutineBarProps {
   items: RoutineItem[];
   onChange?: (items: RoutineItem[]) => void;
+  editable?: boolean;
 }
 
-export function RoutineBar({ items, onChange }: RoutineBarProps) {
+export function RoutineBar({ items, onChange, editable = true }: RoutineBarProps) {
   const [local, setLocal] = useState<RoutineItem[]>(items);
 
   useEffect(() => setLocal(items), [items]);
@@ -36,6 +37,10 @@ export function RoutineBar({ items, onChange }: RoutineBarProps) {
     update([...local, { text: '', done: false }]);
   };
 
+  const removeItem = (idx: number) => {
+    update(local.filter((_, i) => i !== idx));
+  };
+
   return (
     <div className="mb-2 flex flex-wrap gap-2">
       {local.map((item, idx) => (
@@ -45,21 +50,36 @@ export function RoutineBar({ items, onChange }: RoutineBarProps) {
             checked={item.done}
             onChange={() => toggle(idx)}
           />
-          <input
-            className="border-b bg-transparent outline-none"
-            value={item.text}
-            onChange={(e) => changeText(idx, e.target.value)}
-            placeholder={`Task ${idx + 1}`}
-          />
+          {editable ? (
+            <input
+              className="border-b bg-transparent outline-none"
+              value={item.text}
+              onChange={(e) => changeText(idx, e.target.value)}
+              placeholder={`Task ${idx + 1}`}
+            />
+          ) : (
+            <span>{item.text}</span>
+          )}
+          {editable && (
+            <button
+              type="button"
+              onClick={() => removeItem(idx)}
+              className="text-red-500"
+            >
+              ×
+            </button>
+          )}
         </label>
       ))}
-      <button
-        type="button"
-        onClick={addItem}
-        className="rounded bg-gray-200 px-2 py-1 text-sm dark:bg-gray-700"
-      >
-        +
-      </button>
+      {editable && (
+        <button
+          type="button"
+          onClick={addItem}
+          className="rounded bg-gray-200 px-2 py-1 text-sm dark:bg-gray-700"
+        >
+          +
+        </button>
+      )}
     </div>
   );
 }

--- a/web/src/components/WeeklyReview.tsx
+++ b/web/src/components/WeeklyReview.tsx
@@ -47,7 +47,8 @@ export function WeeklyReview() {
 
       for (let i = 0; i < raw.length; i++) {
         const entry = raw[i] ? JSON.parse(raw[i] as string) : {};
-        const routines: { text: string; done: boolean }[] = entry.routines ?? [];
+        const routines: { text: string; done: boolean }[] =
+          entry.routineTicks ?? entry.routines ?? [];
         const todays = new Set<string>();
         routines.forEach((r) => {
           const s = map.get(r.text) ?? { done: 0, total: 0, streak: 0 };


### PR DESCRIPTION
## Summary
- clone `settings.routineTemplate` into new entry `routineTicks`
- allow inline routine item add/remove only when editing today's entry
- use `routineTicks` for weekly habit calculations

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bd3f974a10832ba01e3789e0be42c3