### PR TITLE
feat: add offline s3 attachments

### DIFF
--- a/web/src/components/Attachments.tsx
+++ b/web/src/components/Attachments.tsx
@@ -1,62 +1,126 @@
+import { useEffect, useMemo, useState } from 'react';
+import type React from 'react';
+import {
+  S3Client,
+  PutObjectCommand,
+  GetObjectCommand,
+} from '@aws-sdk/client-s3';
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+import { useAuth } from '../state/useAuth';
+import { attachmentKey } from '../lib/s3Client';
+
 interface AttachmentMeta {
   name: string;
   uuid: string;
 }
 
 interface AttachmentsProps {
-  files: File[];
+  ymd: string;
   existing: AttachmentMeta[];
-  onFilesChange: (files: File[]) => void;
   onExistingChange: (items: AttachmentMeta[]) => void;
 }
 
 export function Attachments({
-  files,
+  ymd,
   existing,
-  onFilesChange,
   onExistingChange,
 }: AttachmentsProps) {
-  const handleSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const list = e.target.files ? Array.from(e.target.files) : [];
-    onFilesChange([...files, ...list]);
-    e.target.value = '';
-  };
+  const [urls, setUrls] = useState<Record<string, string>>({});
+  const region = import.meta.env.VITE_REGION as string;
+  const bucket = import.meta.env.VITE_ENTRY_BUCKET as string;
 
-  const removeFile = (idx: number) => {
-    const next = [...files];
-    next.splice(idx, 1);
-    onFilesChange(next);
+  const client = useMemo(() => {
+    const creds = useAuth.getState().credentialProvider;
+    if (!creds) throw new Error('Not authenticated');
+    return new S3Client({ region, credentials: creds });
+  }, [region]);
+
+  useEffect(() => {
+    const loadUrls = async () => {
+      const entries = await Promise.all(
+        existing.map(async (item) => {
+          const key = attachmentKey(ymd, item.uuid);
+          const url = await getSignedUrl(
+            client,
+            new GetObjectCommand({ Bucket: bucket, Key: key }),
+            { expiresIn: 3600 }
+          );
+          return [item.uuid, url] as const;
+        })
+      );
+      setUrls(Object.fromEntries(entries));
+    };
+    void loadUrls();
+  }, [existing, ymd, client, bucket]);
+
+  const handleSelect = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const list = e.target.files ? Array.from(e.target.files) : [];
+    const added: AttachmentMeta[] = [];
+    const urlMap: Record<string, string> = {};
+    for (const file of list) {
+      const uuid = crypto.randomUUID();
+      const key = attachmentKey(ymd, uuid);
+      await client.send(
+        new PutObjectCommand({
+          Bucket: bucket,
+          Key: key,
+          Body: file,
+          ContentType: file.type,
+          ServerSideEncryption: 'AES256',
+        })
+      );
+      const url = await getSignedUrl(
+        client,
+        new GetObjectCommand({ Bucket: bucket, Key: key }),
+        { expiresIn: 3600 }
+      );
+      added.push({ name: file.name, uuid });
+      urlMap[uuid] = url;
+    }
+    if (added.length > 0) {
+      onExistingChange([...existing, ...added]);
+      setUrls((prev) => ({ ...prev, ...urlMap }));
+    }
+    e.target.value = '';
   };
 
   const removeExisting = (idx: number) => {
     const next = [...existing];
-    next.splice(idx, 1);
+    const [removed] = next.splice(idx, 1);
     onExistingChange(next);
+    setUrls((prev) => {
+      const copy = { ...prev };
+      delete copy[removed.uuid];
+      return copy;
+    });
   };
 
   return (
     <div className="mt-2">
       <input type="file" multiple onChange={handleSelect} />
-      {(existing.length > 0 || files.length > 0) && (
+      {existing.length > 0 && (
         <ul className="mt-2 list-disc pl-4 text-sm">
           {existing.map((f, idx) => (
             <li key={f.uuid}>
               {f.name}
+              {urls[f.uuid] &&
+              /\.(png|jpe?g|gif|webp|bmp|svg)$/i.test(f.name) ? (
+                <img src={urls[f.uuid]} alt={f.name} className="mt-1 h-20" />
+              ) : (
+                urls[f.uuid] && (
+                  <a
+                    href={urls[f.uuid]}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="ml-2 text-blue-600 underline"
+                  >
+                    view
+                  </a>
+                )
+              )}
               <button
                 type="button"
                 onClick={() => removeExisting(idx)}
-                className="ml-2 text-red-600"
-              >
-                remove
-              </button>
-            </li>
-          ))}
-          {files.map((f, idx) => (
-            <li key={`new-${idx}`}>
-              {f.name}
-              <button
-                type="button"
-                onClick={() => removeFile(idx)}
                 className="ml-2 text-red-600"
               >
                 remove
@@ -68,3 +132,4 @@ export function Attachments({
     </div>
   );
 }
+


### PR DESCRIPTION
## Summary
- upload attachments directly from the Attachments component using AWS SDK v3 with SSE-S3 encryption
- show image previews or signed links after upload and store attachment metadata in entries
- streamline DatePage state to persist attachments and trigger uploads offline through the service worker queue

## Testing
- `npm run lint`
- `npm test` (fails: Missing script)

------
https://chatgpt.com/codex/tasks/task_e_68bd42123640832b8427ed52653b6a1c