### PR TITLE
feat: output key infrastructure identifiers

### DIFF
--- a/infra/lib/app-stack.ts
+++ b/infra/lib/app-stack.ts
@@ -11,6 +11,7 @@ import {
   aws_iam as iam,
   aws_ssm as ssm,
   Duration,
+  CfnOutput,
   SecretValue,
 } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
@@ -205,5 +206,23 @@ export class AppStack extends Stack {
       identityPoolId: identityPool.ref,
       roles: { authenticated: authRole.roleArn },
     });
+
+    new CfnOutput(this, 'CloudFrontDistributionUrl', {
+      value: `https://${distro.distributionDomainName}`,
+    });
+
+    new CfnOutput(this, 'CloudFrontDistributionDomain', {
+      value: distro.distributionDomainName,
+    });
+
+    new CfnOutput(this, 'UserPoolId', { value: userPool.userPoolId });
+
+    new CfnOutput(this, 'UserPoolClientId', {
+      value: userPoolClient.userPoolClientId,
+    });
+
+    new CfnOutput(this, 'IdentityPoolId', { value: identityPool.ref });
+
+    new CfnOutput(this, 'UserdataBucketName', { value: userBucket.bucketName });
   }
 }


### PR DESCRIPTION
## Summary
- output CloudFront distribution URL and domain
- expose Cognito user pool, client, and identity pool identifiers
- surface userdata bucket name for easier reference

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bd4583ab80832b96235afce29de3f3