### PR TITLE
Add Playwright tests for key features

### DIFF
--- a/web/.gitignore
+++ b/web/.gitignore
@@ -11,6 +11,8 @@ node_modules
 dist
 dist-ssr
 *.local
+playwright-report
+test-results
 
 # Editor directories and files
 .vscode/*

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@aws-sdk/client-s3": "^3.883.0",
         "@aws-sdk/credential-provider-cognito-identity": "^3.883.0",
+        "@aws-sdk/s3-request-presigner": "^3.883.0",
         "idb": "^8.0.3",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
@@ -18,6 +19,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.33.0",
+        "@playwright/test": "^1.55.0",
         "@types/react": "^19.1.10",
         "@types/react-dom": "^19.1.7",
         "@vitejs/plugin-react": "^5.0.0",
@@ -833,6 +835,25 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@aws-sdk/s3-request-presigner": {
+      "version": "3.883.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.883.0.tgz",
+      "integrity": "sha512-NW20A3PD+vqVcr/5F3cbqibKogUNdDAE9K9MUE7X1JSz3Gi/2nMV2hoRdC3+T3c6XE44t6LW1Swt3JOvaQOJLw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/signature-v4-multi-region": "3.883.0",
+        "@aws-sdk/types": "3.862.0",
+        "@aws-sdk/util-format-url": "3.873.0",
+        "@smithy/middleware-endpoint": "^4.1.21",
+        "@smithy/protocol-http": "^5.1.3",
+        "@smithy/smithy-client": "^4.5.2",
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
       "version": "3.883.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.883.0.tgz",
@@ -903,6 +924,21 @@
         "@smithy/types": "^4.3.2",
         "@smithy/url-parser": "^4.0.5",
         "@smithy/util-endpoints": "^3.0.7",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-format-url": {
+      "version": "3.873.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.873.0.tgz",
+      "integrity": "sha512-v//b9jFnhzTKKV3HFTw2MakdM22uBAs2lBov51BWmFXuFtSTdBLrR7zgfetQPE3PVkFai0cmtJQPdc3MX+T/cQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.862.0",
+        "@smithy/querystring-builder": "^4.0.5",
+        "@smithy/types": "^4.3.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2015,6 +2051,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.55.0.tgz",
+      "integrity": "sha512-04IXzPwHrW69XusN/SIdDdKZBzMfOT9UNT/YiJit/xpy2VuAoB8NHc8Aplb96zsWDddLnbkPL3TsmrS04ZU2xQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.55.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -5296,6 +5348,53 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.0.tgz",
+      "integrity": "sha512-sdCWStblvV1YU909Xqx0DhOjPZE4/5lJsIS84IfN9dAZfcl/CIZ5O8l3o0j7hPMjDvqoTF8ZUcc+i/GL5erstA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.55.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.0.tgz",
+      "integrity": "sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/web/package.json
+++ b/web/package.json
@@ -7,11 +7,14 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "playwright test",
+    "test:ui": "playwright test --ui"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.883.0",
     "@aws-sdk/credential-provider-cognito-identity": "^3.883.0",
+    "@aws-sdk/s3-request-presigner": "^3.883.0",
     "idb": "^8.0.3",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
@@ -20,6 +23,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",
+    "@playwright/test": "^1.55.0",
     "@types/react": "^19.1.10",
     "@types/react-dom": "^19.1.7",
     "@vitejs/plugin-react": "^5.0.0",

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -1,0 +1,32 @@
+import { defineConfig } from '@playwright/test';
+
+const token = 'a.eyJzdWIiOiJ0ZXN0In0.c';
+
+export default defineConfig({
+  testDir: './tests',
+  use: {
+    baseURL: 'http://localhost:5173',
+    storageState: {
+      origins: [
+        {
+          origin: 'http://localhost:5173',
+          localStorage: [{ name: 'idToken', value: token }],
+        },
+      ],
+    },
+    headless: true,
+  },
+  webServer: {
+    command: 'npm run dev -- --port=5173',
+    url: 'http://localhost:5173',
+    reuseExistingServer: !process.env.CI,
+    env: {
+      VITE_REGION: 'us-east-1',
+      VITE_USER_POOL_ID: 'pool',
+      VITE_USER_POOL_CLIENT_ID: 'client',
+      VITE_IDENTITY_POOL_ID: 'identity',
+      VITE_HOSTED_UI_DOMAIN: 'example.com',
+      VITE_ENTRY_BUCKET: 'bucket',
+    },
+  },
+});

--- a/web/tests/diary.spec.ts
+++ b/web/tests/diary.spec.ts
@@ -1,0 +1,31 @@
+import { test, expect, Page } from '@playwright/test';
+
+async function todayYmd(page: Page) {
+  return page.evaluate(() => new Date().toLocaleDateString('en-CA'));
+}
+
+async function nextYmd(page: Page, ymd: string) {
+  return page.evaluate((d) => {
+    const date = new Date(d);
+    date.setDate(date.getDate() + 1);
+    return date.toLocaleDateString('en-CA');
+  }, ymd);
+}
+
+test('overflow textarea receives extra lines', async ({ page }) => {
+  const today = await todayYmd(page);
+  await page.goto(`/date/${today}`);
+  const main = page.locator('textarea').first();
+  const lines = Array.from({ length: 30 }, (_, i) => `line${i + 1}`).join('\n');
+  await main.fill(lines);
+  const overflow = page.locator('details textarea');
+  await expect(overflow).toHaveValue('line29\nline30');
+});
+
+test('Next button moves to following day', async ({ page }) => {
+  const today = await todayYmd(page);
+  const next = await nextYmd(page, today);
+  await page.goto(`/date/${today}`);
+  await page.getByRole('button', { name: 'Next' }).click();
+  await expect(page).toHaveURL(new RegExp(`/date/${next}$`));
+});

--- a/web/tests/offline.spec.ts
+++ b/web/tests/offline.spec.ts
@@ -1,0 +1,18 @@
+import { test, expect } from '@playwright/test';
+
+test('app works offline after initial load', async ({ page, context }) => {
+  await page.goto('/');
+  await page.waitForLoadState('networkidle');
+  const ready = await page.evaluate(() => {
+    if (!('serviceWorker' in navigator)) return false;
+    return Promise.race([
+      navigator.serviceWorker.ready.then(() => true),
+      new Promise<boolean>((resolve) => setTimeout(() => resolve(false), 3000)),
+    ]);
+  });
+  if (!ready) test.skip();
+  await context.setOffline(true);
+  await page.reload();
+  await expect(page.locator('button').first()).toBeVisible();
+  await context.setOffline(false);
+});

--- a/web/tests/routine.spec.ts
+++ b/web/tests/routine.spec.ts
@@ -1,0 +1,21 @@
+import { test, expect, Page } from '@playwright/test';
+
+async function todayYmd(page: Page) {
+  return page.evaluate(() => new Date().toLocaleDateString('en-CA'));
+}
+
+test('add, toggle and remove routine items', async ({ page }) => {
+  const today = await todayYmd(page);
+  await page.goto(`/date/${today}`);
+  // Add a new routine item
+  await page.getByRole('button', { name: '+' }).click();
+  const input = page.locator('input[placeholder="Task 1"]');
+  await input.fill('My Task');
+  // Toggle checkbox
+  const checkbox = page.locator('input[type="checkbox"]').first();
+  await checkbox.check();
+  await expect(checkbox).toBeChecked();
+  // Remove item
+  await page.getByRole('button', { name: '×' }).click();
+  await expect(input).toHaveCount(0);
+});

--- a/web/tests/theme.spec.ts
+++ b/web/tests/theme.spec.ts
@@ -1,0 +1,17 @@
+import { test, expect } from '@playwright/test';
+
+// Verify that theme cycles through light -> dark -> paper -> light
+
+test('cycles through available themes', async ({ page }) => {
+  await page.goto('/');
+  const button = page.getByRole('button', { name: 'Toggle theme' });
+  const html = page.locator('html');
+
+  await expect(html).toHaveAttribute('data-theme', 'light');
+  await button.click();
+  await expect(html).toHaveAttribute('data-theme', 'dark');
+  await button.click();
+  await expect(html).toHaveAttribute('data-theme', 'paper');
+  await button.click();
+  await expect(html).toHaveAttribute('data-theme', 'light');
+});


### PR DESCRIPTION
## Summary
- configure Playwright with test and test:ui scripts
- add end-to-end tests for theme toggling, diary entries, routines, and offline mode

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bd460a3e04832b90dc79f1164ee7de