### PR TITLE
feat: add offline banner

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2,6 +2,7 @@ import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import { useEffect } from 'react';
 import { useAuth } from './state/useAuth';
 import { ThemeButton } from './components/ThemeButton';
+import { OfflineBanner } from './components/OfflineBanner';
 import CalendarPage from './pages/CalendarPage';
 import DatePage from './pages/DatePage';
 import SettingsPage from './pages/SettingsPage';
@@ -9,6 +10,7 @@ import SettingsPage from './pages/SettingsPage';
 function Layout() {
   return (
     <div className="flex min-h-screen flex-col">
+      <OfflineBanner />
       <header className="flex justify-end p-4">
         <ThemeButton />
       </header>

--- a/web/src/components/OfflineBanner.tsx
+++ b/web/src/components/OfflineBanner.tsx
@@ -1,0 +1,28 @@
+import { useEffect, useState } from 'react';
+
+export function OfflineBanner() {
+  const [online, setOnline] = useState(navigator.onLine);
+
+  useEffect(() => {
+    const handleOnline = () => setOnline(true);
+    const handleOffline = () => setOnline(false);
+
+    window.addEventListener('online', handleOnline);
+    window.addEventListener('offline', handleOffline);
+
+    return () => {
+      window.removeEventListener('online', handleOnline);
+      window.removeEventListener('offline', handleOffline);
+    };
+  }, []);
+
+  if (online) {
+    return null;
+  }
+
+  return (
+    <div className="bg-red-600 p-2 text-center text-white">
+      You are offline
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- show an offline banner across the app whenever `navigator.onLine` is false
- integrate offline banner into the app layout for visibility on every page

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bd48cd86dc832b9c29cd8c29fda2e6