### PR TITLE
feat: add landing page with provider logins

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,5 +1,4 @@
 import { BrowserRouter, Routes, Route, Navigate, Link } from 'react-router-dom';
-import { useEffect } from 'react';
 import { useAuth } from './state/useAuth';
 import { ThemeButton } from './components/ThemeButton';
 import { OfflineBanner } from './components/OfflineBanner';
@@ -7,6 +6,7 @@ import CalendarPage from './pages/CalendarPage';
 import DatePage from './pages/DatePage';
 import SettingsPage from './pages/SettingsPage';
 import SearchPage from './pages/SearchPage';
+import LandingPage from './pages/LandingPage';
 
 function Layout() {
   return (
@@ -34,16 +34,16 @@ function Layout() {
 }
 
 export default function App() {
-  const { status, login } = useAuth();
-
-  useEffect(() => {
-    if (status === 'unauthenticated') {
-      login();
-    }
-  }, [status, login]);
+  const { status } = useAuth();
 
   if (status !== 'authenticated') {
-    return null;
+    return (
+      <BrowserRouter>
+        <Routes>
+          <Route path="*" element={<LandingPage />} />
+        </Routes>
+      </BrowserRouter>
+    );
   }
 
   return (

--- a/web/src/pages/LandingPage.tsx
+++ b/web/src/pages/LandingPage.tsx
@@ -1,0 +1,34 @@
+import { useAuth } from '../state/useAuth';
+
+export default function LandingPage() {
+  const { login } = useAuth();
+
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center gap-6 p-4 text-center">
+      <h1 className="text-4xl font-bold">Welcome to AutoDiary</h1>
+      <div className="flex flex-col gap-4">
+        <button
+          type="button"
+          className="rounded bg-blue-500 px-4 py-2 text-white"
+          onClick={() => login('Google')}
+        >
+          Sign in with Google
+        </button>
+        <button
+          type="button"
+          className="rounded bg-blue-500 px-4 py-2 text-white"
+          onClick={() => login('Microsoft')}
+        >
+          Sign in with Microsoft
+        </button>
+        <button
+          type="button"
+          className="rounded bg-blue-500 px-4 py-2 text-white"
+          onClick={() => login('Apple')}
+        >
+          Sign in with Apple
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/web/src/state/useAuth.ts
+++ b/web/src/state/useAuth.ts
@@ -9,7 +9,7 @@ interface AuthState {
   /** per-user prefix derived from the id token */
   userPrefix?: string;
   /** redirect the browser to the Cognito Hosted UI */
-  login: () => void;
+  login: (identityProvider?: string) => void;
   /** clear stored tokens and re-authenticate */
   logout: () => void;
 }
@@ -30,10 +30,13 @@ const redirectUri = typeof window !== 'undefined' ? window.location.origin : '';
 
 export const useAuth = create<AuthState>((set) => ({
   status: 'loading',
-  login: () => {
+  login: (identityProvider) => {
     const url =
       `https://${hostedUiDomain}/login?` +
-      `client_id=${clientId}&response_type=token&scope=openid+profile&redirect_uri=${encodeURIComponent(redirectUri)}`;
+      `client_id=${clientId}&response_type=token&scope=openid+profile&redirect_uri=${encodeURIComponent(redirectUri)}` +
+      (identityProvider
+        ? `&identity_provider=${encodeURIComponent(identityProvider)}`
+        : '');
     window.location.assign(url);
   },
   logout: () => {


### PR DESCRIPTION
## Summary
- add landing page with hero message and social login buttons
- support choosing identity provider in auth login
- send unauthenticated users to landing page instead of auto-login

## Testing
- `npm run lint`
- `npm test` *(fails: browserType.launch executable missing; npx playwright install 403 Domain forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bd553b4cf0832bac43dffbf17e8243