### PR TITLE
feat: respect stored theme on load

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -1,7 +1,13 @@
 <!doctype html>
-<html lang="en" data-theme="light">
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <script>
+      const theme = localStorage.theme;
+      if (theme) {
+        document.documentElement.dataset.theme = theme;
+      }
+    </script>
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <link rel="manifest" href="/manifest.json" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />


### PR DESCRIPTION
## Summary
- load stored theme from localStorage before stylesheets
- remove hard-coded theme attribute

## Testing
- `npm test` *(fails: playwright: not found)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bd56ee2a10832b847336a41c23e7e0