### PR TITLE
feat: apply handwriting font to diary entries

### DIFF
--- a/web/src/index.css
+++ b/web/src/index.css
@@ -20,10 +20,6 @@ html[data-theme='paper'] {
   --paper: #f8f5e4;
 }
 
-html[data-theme='paper'] .paper-page {
-  font-family: 'Patrick Hand', cursive;
-}
-
 body {
   @apply bg-[var(--bg)] text-[var(--text)] min-h-screen;
 }
@@ -32,4 +28,8 @@ body {
   background: var(--paper);
   background-image: linear-gradient(#e0dccc 1px, transparent 1px);
   background-size: 100% 1.5rem;
+}
+
+.handwriting {
+  font-family: 'Patrick Hand', cursive;
 }

--- a/web/src/pages/DatePage.tsx
+++ b/web/src/pages/DatePage.tsx
@@ -208,7 +208,7 @@ export default function DatePage() {
 
       <textarea
         rows={28}
-        className="w-full resize-none bg-transparent outline-none"
+        className="handwriting w-full resize-none bg-transparent outline-none"
         value={mainText}
         onChange={handleMainChange}
       />
@@ -216,7 +216,7 @@ export default function DatePage() {
       <details className="mt-2" open={Boolean(overflowText)}>
         <summary>Overflow</summary>
         <textarea
-          className="mt-2 w-full resize-none bg-transparent outline-none"
+          className="handwriting mt-2 w-full resize-none bg-transparent outline-none"
           value={overflowText}
           onChange={handleOverflowChange}
           rows={Math.max(overflowText.split('\n').length, 1)}


### PR DESCRIPTION
## Summary
- introduce `.handwriting` class for Patrick Hand font
- use handwriting font only on diary text areas

## Testing
- `npm run lint`
- `npm test` *(fails: browserType.launch: Executable doesn't exist / missing system dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68bd5b858890832babb280c42ea102ec