### PR TITLE
Add connectors settings page

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -8,6 +8,7 @@ import SettingsPage from './pages/SettingsPage';
 import SearchPage from './pages/SearchPage';
 import LandingPage from './pages/LandingPage';
 import WeeklyReviewPage from './pages/WeeklyReviewPage';
+import ConnectorsPage from './pages/ConnectorsPage';
 
 function Layout() {
   return (
@@ -18,6 +19,7 @@ function Layout() {
           <Link to="/calendar">Calendar</Link>
           <Link to="/search">Search</Link>
           <Link to="/weekly">Weekly Review</Link>
+          <Link to="/connectors">Connectors</Link>
           <Link to="/settings">Settings</Link>
         </nav>
         <ThemeButton />
@@ -29,6 +31,7 @@ function Layout() {
           <Route path="/date/:ymd" element={<DatePage />} />
           <Route path="/search" element={<SearchPage />} />
           <Route path="/weekly" element={<WeeklyReviewPage />} />
+          <Route path="/connectors" element={<ConnectorsPage />} />
           <Route path="/settings" element={<SettingsPage />} />
         </Routes>
       </main>

--- a/web/src/pages/ConnectorsPage.tsx
+++ b/web/src/pages/ConnectorsPage.tsx
@@ -1,0 +1,78 @@
+import { useEffect, useState } from 'react';
+import {
+  getConnectorStatus,
+  putConnectorStatus,
+  type ConnectorStatus,
+} from '../lib/s3Client';
+
+const providers = [
+  { key: 'gmail', name: 'Gmail' },
+  { key: 'google-calendar', name: 'Google Calendar' },
+  { key: 'google-photos', name: 'Google Photos' },
+  { key: 'linkedin', name: 'LinkedIn' },
+] as const;
+
+export default function ConnectorsPage() {
+  const [statuses, setStatuses] = useState<Record<string, ConnectorStatus | null>>({});
+
+  useEffect(() => {
+    (async () => {
+      for (const p of providers) {
+        try {
+          const status = await getConnectorStatus(p.key);
+          setStatuses((s) => ({ ...s, [p.key]: status }));
+        } catch (err) {
+          console.error('Failed to load connector', p.key, err);
+        }
+      }
+    })();
+  }, []);
+
+  const update = async (provider: string, status: ConnectorStatus) => {
+    try {
+      await putConnectorStatus(provider, status);
+      setStatuses((s) => ({ ...s, [provider]: status }));
+    } catch (err) {
+      console.error('Failed to update connector', provider, err);
+    }
+  };
+
+  return (
+    <div className="p-4">
+      <h1 className="mb-4 text-xl font-bold">Connectors</h1>
+      <ul className="space-y-4">
+        {providers.map((p) => (
+          <li key={p.key} className="flex items-center justify-between gap-4">
+            <span className="font-medium">{p.name}</span>
+            <span className="text-sm">
+              Status: {statuses[p.key] ?? 'unknown'}
+            </span>
+            <div className="flex gap-2">
+              <button
+                type="button"
+                className="rounded bg-green-500 px-2 py-1 text-white"
+                onClick={() => update(p.key, 'added')}
+              >
+                Add
+              </button>
+              <button
+                type="button"
+                className="rounded bg-yellow-500 px-2 py-1 text-white"
+                onClick={() => update(p.key, 'paused')}
+              >
+                Pause
+              </button>
+              <button
+                type="button"
+                className="rounded bg-red-500 px-2 py-1 text-white"
+                onClick={() => update(p.key, 'revoked')}
+              >
+                Revoke
+              </button>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add connectors page with Gmail, Google Calendar, Google Photos, and LinkedIn controls
- store connector state in S3 via new helpers
- link connectors page in nav

## Testing
- `npm run lint`
- `npm test` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1187/chrome-linux/headless_shell)*

------
https://chatgpt.com/codex/tasks/task_e_68bd62ee7290832bb7ac1a328f03097b