### PR TITLE
feat: add diary store and integrate pages

### DIFF
--- a/web/src/pages/CalendarPage.tsx
+++ b/web/src/pages/CalendarPage.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { CalendarGrid } from '../components/CalendarGrid';
 import { listMonth } from '../lib/s3Client';
 import { downloadMonthJSON, downloadMonthMarkdown } from '../lib/export';
+import { useDiaryStore } from '../state/useDiaryStore';
 
 function pad(n: number) {
   return n.toString().padStart(2, '0');
@@ -15,6 +16,8 @@ export default function CalendarPage() {
   const month = mm ? parseInt(mm, 10) : today.getMonth() + 1;
   const [entries, setEntries] = useState<string[]>([]);
   const navigate = useNavigate();
+  const setCurrentDate = useDiaryStore((s) => s.setCurrentDate);
+  const loadEntry = useDiaryStore((s) => s.loadEntry);
 
   useEffect(() => {
     listMonth(String(year), pad(month)).then(setEntries).catch(() => setEntries([]));
@@ -29,7 +32,11 @@ export default function CalendarPage() {
         month={month}
         entries={entries}
         today={todayYmd}
-        onSelect={(ymd) => navigate(`/date/${ymd}`)}
+        onSelect={(ymd) => {
+          setCurrentDate(ymd);
+          void loadEntry(ymd);
+          navigate(`/date/${ymd}`);
+        }}
       />
       <div className="mt-4 flex gap-4">
         <button

--- a/web/src/state/useDiaryStore.ts
+++ b/web/src/state/useDiaryStore.ts
@@ -1,0 +1,97 @@
+import { create } from 'zustand';
+import { getEntry, putEntry, getSettings } from '../lib/s3Client';
+import { formatYmd } from '../lib/date';
+import type { RoutineItem } from '../components/RoutineBar';
+
+interface DiaryEntry {
+  text: string;
+  routineTicks: RoutineItem[];
+  attachments: { name: string; uuid: string }[];
+  city?: string;
+  desc?: string;
+  tmax?: number;
+  tmin?: number;
+}
+
+interface DiaryState {
+  currentDate: string;
+  entries: Record<string, DiaryEntry>;
+  setCurrentDate: (ymd: string) => void;
+  loadEntry: (ymd: string) => Promise<void>;
+  saveEntry: (ymd: string) => Promise<void>;
+  updateEntry: (ymd: string, entry: Partial<DiaryEntry>) => void;
+}
+
+const todayYmd = formatYmd(new Date());
+
+export const useDiaryStore = create<DiaryState>((set, get) => ({
+  currentDate: todayYmd,
+  entries: {},
+  setCurrentDate: (ymd) => set({ currentDate: ymd }),
+  loadEntry: async (ymd) => {
+    if (get().entries[ymd]) return;
+    try {
+      const raw = await getEntry(ymd);
+      if (raw) {
+        const parsed = JSON.parse(raw) as Record<string, unknown>;
+        const entry: DiaryEntry = {
+          text: parsed.text ?? '',
+          routineTicks: parsed.routineTicks ?? parsed.routines ?? [],
+          attachments: parsed.attachments ?? [],
+          city: parsed.city,
+          desc: parsed.desc,
+          tmax: parsed.tmax,
+          tmin: parsed.tmin,
+        };
+        set((state) => ({ entries: { ...state.entries, [ymd]: entry } }));
+      } else {
+        const settings = await getSettings();
+        const routineTicks =
+          settings?.routineTemplate?.map((r) => ({ text: r.text, done: false })) ?? [];
+        const entry: DiaryEntry = { text: '', routineTicks, attachments: [] };
+        set((state) => ({ entries: { ...state.entries, [ymd]: entry } }));
+      }
+    } catch (err) {
+      console.error('Failed to load entry', err);
+    }
+  },
+  saveEntry: async (ymd) => {
+    const entry = get().entries[ymd];
+    if (!entry) return;
+    try {
+      await putEntry(ymd, JSON.stringify(entry));
+    } catch (err) {
+      const status = (err as { $metadata?: { httpStatusCode?: number } }).$metadata?.httpStatusCode;
+      if (status === 412) {
+        try {
+          const latestRaw = await getEntry(ymd);
+          const latest = latestRaw ? JSON.parse(latestRaw) : {};
+          const remoteText = (latest as { text?: string }).text ?? '';
+          const localText = entry.text ?? '';
+          let resolved: DiaryEntry = entry;
+          if (remoteText !== localText) {
+            const merge = window.confirm(
+              `Entry has changed elsewhere.\n\nRemote:\n${remoteText}\n\nLocal:\n${localText}\n\nPress OK to merge or Cancel to overwrite.`
+            );
+            resolved = merge
+              ? { ...latest, ...entry, text: `${remoteText}\n${localText}` }
+              : { ...latest, ...entry };
+          } else {
+            resolved = { ...latest, ...entry };
+          }
+          set((state) => ({ entries: { ...state.entries, [ymd]: resolved } }));
+          await putEntry(ymd, JSON.stringify(resolved));
+        } catch (e) {
+          console.error('Failed to resolve entry conflict', e);
+        }
+      } else {
+        console.error('Failed to save entry', err);
+      }
+    }
+  },
+  updateEntry: (ymd, partial) =>
+    set((state) => ({
+      entries: { ...state.entries, [ymd]: { ...state.entries[ymd], ...partial } },
+    })),
+}));
+


### PR DESCRIPTION
## Summary
- add Zustand diary store for current date and entry caching
- refactor DatePage and CalendarPage to use diary store for navigation and persistence

## Testing
- `npm run lint`
- `npm test` *(fails: Executable doesn't exist at /root/.cache/ms-playwright/...)*

------
https://chatgpt.com/codex/tasks/task_e_68bd687590f0832ba0e8896546edf002