### PR TITLE
feat: show theme button on landing page

### DIFF
--- a/web/src/pages/LandingPage.tsx
+++ b/web/src/pages/LandingPage.tsx
@@ -1,10 +1,14 @@
 import { useAuth } from '../state/useAuth';
+import { ThemeButton } from '../components/ThemeButton';
 
 export default function LandingPage() {
   const { login } = useAuth();
 
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center gap-6 p-4 text-center">
+    <div className="relative flex min-h-screen flex-col items-center justify-center gap-6 p-4 text-center">
+      <div className="absolute right-4 top-4">
+        <ThemeButton />
+      </div>
       <h1 className="text-4xl font-bold">Welcome to AutoDiary</h1>
       <div className="flex flex-col gap-4">
         <button


### PR DESCRIPTION
## Summary
- render ThemeButton on the unauthenticated landing page

## Testing
- `npm test` *(fails: Download failed: server returned code 403 body 'Domain forbidden')*
- `npx playwright install` *(fails: Download failed: server returned code 403 body 'Domain forbidden')*

------
https://chatgpt.com/codex/tasks/task_e_68bd6bab0e6c832b94a42e529d478d06