### PR TITLE
feat: add test mode auth

### DIFF
--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -27,6 +27,7 @@ export default defineConfig({
       VITE_IDENTITY_POOL_ID: 'identity',
       VITE_HOSTED_UI_DOMAIN: 'example.com',
       VITE_ENTRY_BUCKET: 'bucket',
+      VITE_TEST_MODE: 'true',
     },
   },
 });


### PR DESCRIPTION
## Summary
- auto-authenticate in test mode when VITE_TEST_MODE is set
- propagate VITE_TEST_MODE through Playwright config for tests

## Testing
- `npm test` *(fails: browserType.launch: Executable doesn't exist)*

------
https://chatgpt.com/codex/tasks/task_e_68bd6f37f330832b8864e9b28eea8f20