### PR TITLE
Use abbreviated date format and simplify header weather

### DIFF
--- a/web/src/lib/date.ts
+++ b/web/src/lib/date.ts
@@ -13,13 +13,23 @@ export function parseYmd(ymd: string): Date {
   return new Date(y, m - 1, day);
 }
 
-/** Human friendly date like 'Monday, January 1, 2024' */
+/** Human friendly date like 'Mon, 08 Sep 2025' */
 export function displayDate(ymd: string): string {
   const d = parseYmd(ymd);
-  return d.toLocaleDateString(undefined, {
-    weekday: 'long',
-    year: 'numeric',
-    month: 'long',
-    day: 'numeric',
-  });
+  const weekdays = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+  const months = [
+    'Jan',
+    'Feb',
+    'Mar',
+    'Apr',
+    'May',
+    'Jun',
+    'Jul',
+    'Aug',
+    'Sep',
+    'Oct',
+    'Nov',
+    'Dec',
+  ];
+  return `${weekdays[d.getDay()]}, ${pad(d.getDate())} ${months[d.getMonth()]} ${d.getFullYear()}`;
 }

--- a/web/src/pages/DatePage.tsx
+++ b/web/src/pages/DatePage.tsx
@@ -179,11 +179,9 @@ export default function DatePage() {
         <div className="text-xl font-bold">{displayDate(ymdStr)}</div>
         <div className="flex items-center gap-2 text-sm">
           {location?.city && <span>{location.city}</span>}
-          {weather && (
-            <span>
-              {weather.desc} {weather.tmin}–{weather.tmax}°C
-            </span>
-          )}
+          {location?.city && weather && <span>•</span>}
+          {weather && <span>{weather.tmax}°C {weather.desc}</span>}
+          {(location?.city || weather) && <span>•</span>}
           <button
             className="text-xs underline"
             onClick={() => fetchMeta(true)}


### PR DESCRIPTION
## Summary
- format `displayDate` with short weekday/month names (`Mon, 08 Sep 2025`)
- show single temperature plus description and bullet separators in date page header

## Testing
- `npm run lint`
- `npm test` *(fails: browserType.launch: Executable doesn't exist; suggested `npx playwright install`)*

------
https://chatgpt.com/codex/tasks/task_e_68bd727c868c832b90e591e2a1fa302d