### PR TITLE
Position ink gauge at top of diary page

### DIFF
--- a/web/src/components/InkGauge.tsx
+++ b/web/src/components/InkGauge.tsx
@@ -1,12 +1,17 @@
 interface InkGaugeProps {
   used: number;
   total: number;
+  className?: string;
 }
 
-export function InkGauge({ used, total }: InkGaugeProps) {
+export function InkGauge({ used, total, className }: InkGaugeProps) {
   const percent = total > 0 ? Math.min(100, (used / total) * 100) : 0;
   return (
-    <div className="h-2 w-full rounded bg-gray-300 dark:bg-gray-700">
+    <div
+      className={`h-2 w-full rounded bg-gray-300 dark:bg-gray-700 ${
+        className ?? ''
+      }`}
+    >
       <div
         className="h-full rounded bg-blue-500"
         style={{ width: `${percent}%` }}

--- a/web/src/pages/DatePage.tsx
+++ b/web/src/pages/DatePage.tsx
@@ -174,7 +174,12 @@ export default function DatePage() {
   const overflowText = lines.length > 28 ? lines.slice(28).join('\n') : '';
 
   return (
-    <div className="paper-page p-4">
+    <div className="paper-page relative p-4">
+      <InkGauge
+        used={Math.min(lines.length, 28)}
+        total={28}
+        className="absolute right-2 top-2 w-20"
+      />
       <header className="mb-4">
         <div className="text-xl font-bold">{displayDate(ymdStr)}</div>
         <div className="flex items-center gap-2 text-sm">
@@ -217,10 +222,6 @@ export default function DatePage() {
           rows={Math.max(overflowText.split('\n').length, 1)}
         />
       </details>
-
-      <div className="my-2">
-        <InkGauge used={Math.min(lines.length, 28)} total={28} />
-      </div>
 
       <Attachments
         ymd={ymdStr}


### PR DESCRIPTION
## Summary
- wrap diary page with a `relative` container and float ink gauge to top-right
- allow `InkGauge` component to accept extra classes for positioning

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bd732dcc3c832bae34f2d906b39973