### PR TITLE
feat: nest location and weather data

### DIFF
--- a/web/src/lib/weather.ts
+++ b/web/src/lib/weather.ts
@@ -73,9 +73,14 @@ export async function refreshWeather(
   const city = loc.city ?? (await reverseGeocode(loc.lat, loc.lon));
   const weather = await getDailyWeather(loc.lat, loc.lon, date);
   if (!weather) return null;
-  if (city) entry.city = city;
-  entry.tmax = weather.tmax;
-  entry.tmin = weather.tmin;
-  entry.desc = weather.desc;
+  if (city) {
+    entry.loc = { ...(entry.loc as Record<string, unknown>), city };
+  }
+  entry.loc = { ...(entry.loc as Record<string, unknown>), lat: loc.lat, lon: loc.lon };
+  entry.weather = {
+    tmax: weather.tmax,
+    tmin: weather.tmin,
+    desc: weather.desc,
+  };
   return { location: { ...loc, city }, weather };
 }

--- a/web/src/pages/DatePage.tsx
+++ b/web/src/pages/DatePage.tsx
@@ -47,16 +47,8 @@ export default function DatePage() {
     setText(entry?.text ?? '');
     setRoutineTicks(entry?.routineTicks ?? []);
     setAttachments(entry?.attachments ?? []);
-    if (entry?.city) {
-      setLocation({ lat: 0, lon: 0, city: entry.city });
-    }
-    if (entry?.desc) {
-      setWeather({
-        tmax: entry.tmax as number,
-        tmin: entry.tmin as number,
-        desc: entry.desc as string,
-      });
-    }
+    setLocation(entry?.loc ?? null);
+    setWeather(entry?.weather ?? null);
     setLoaded(true);
   }, [ymdStr, loadEntryFromStore]);
 
@@ -86,29 +78,20 @@ export default function DatePage() {
       const current = useDiaryStore.getState().entries[ymdStr] || {};
       if (
         !force &&
-        current.city &&
-        current.desc &&
-        typeof current.city === 'string' &&
-        typeof current.desc === 'string'
+        current.loc?.city &&
+        current.weather?.desc &&
+        typeof current.loc.city === 'string' &&
+        typeof current.weather.desc === 'string'
       ) {
-        setLocation({ lat: 0, lon: 0, city: current.city });
-        setWeather({
-          tmax: current.tmax as number,
-          tmin: current.tmin as number,
-          desc: current.desc as string,
-        });
+        setLocation(current.loc);
+        setWeather(current.weather);
         return;
       }
       const res = await refreshWeather(current, ymdStr);
       if (!res) return;
       setLocation(res.location);
       setWeather(res.weather);
-      updateEntry(ymdStr, {
-        city: res.location.city,
-        desc: res.weather.desc,
-        tmax: res.weather.tmax,
-        tmin: res.weather.tmin,
-      });
+      updateEntry(ymdStr, { loc: res.location, weather: res.weather });
     },
     [ymdStr, updateEntry]
   );
@@ -181,14 +164,12 @@ export default function DatePage() {
         className="absolute right-2 top-2 w-20"
       />
       <header className="mb-4">
-        <div className="text-xl font-bold">{displayDate(ymdStr)}</div>
-        <div className="flex items-center gap-2 text-sm">
-          {location?.city && <span>{location.city}</span>}
-          {location?.city && weather && <span>•</span>}
-          {weather && <span>{weather.tmax}°C {weather.desc}</span>}
-          {(location?.city || weather) && <span>•</span>}
+        <div className="flex items-center gap-2 text-xl font-bold">
+          <span>{displayDate(ymdStr)}</span>
+          {location?.city && <span>• {location.city}</span>}
+          {weather && <span>• {weather.tmax}°C, {weather.desc}</span>}
           <button
-            className="text-xs underline"
+            className="text-xs font-normal underline"
             onClick={() => fetchMeta(true)}
             type="button"
           >


### PR DESCRIPTION
## Summary
- add nested `loc` and `weather` fields to diary entries
- show city and weather in DatePage header
- normalize old entries when reading/writing via S3 client

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bd77772c90832bbccc52177098c312