### PR TITLE
Track ink usage in diary entries

### DIFF
--- a/web/src/lib/s3Client.ts
+++ b/web/src/lib/s3Client.ts
@@ -41,6 +41,7 @@ function connectorKey(provider: string) {
 }
 
 interface RawEntry {
+  text?: string;
   loc?: { lat?: number; lon?: number; city?: string };
   weather?: { tmax?: number; tmin?: number; desc?: string };
   city?: string;
@@ -49,6 +50,7 @@ interface RawEntry {
   tmax?: number;
   tmin?: number;
   desc?: string;
+  inkUsed?: number;
   [key: string]: unknown;
 }
 
@@ -76,6 +78,9 @@ function normalizeEntry(body: string): string {
       delete data.tmax;
       delete data.tmin;
       delete data.desc;
+    }
+    if (typeof data.text === 'string' && typeof data.inkUsed !== 'number') {
+      data.inkUsed = data.text.length;
     }
     return JSON.stringify(data);
   } catch {

--- a/web/src/pages/DatePage.tsx
+++ b/web/src/pages/DatePage.tsx
@@ -11,6 +11,8 @@ import { RoutineBar, type RoutineItem } from '../components/RoutineBar';
 import { Attachments } from '../components/Attachments';
 import { useDiaryStore } from '../state/useDiaryStore';
 
+const INK_TOTAL = 1000;
+
 export default function DatePage() {
   const { ymd } = useParams<{ ymd: string }>();
   const navigate = useNavigate();
@@ -40,6 +42,7 @@ export default function DatePage() {
   const [weather, setWeather] = useState<Weather | null>(null);
   const [fetched, setFetched] = useState(false);
   const [loaded, setLoaded] = useState(false);
+  const inkUsed = text.length;
 
   const loadEntry = useCallback(async () => {
     await loadEntryFromStore(ymdStr);
@@ -110,7 +113,7 @@ export default function DatePage() {
     return () => {
       if (saveTimer.current) window.clearTimeout(saveTimer.current);
     };
-  }, [text, routineTicks, attachments, location, weather, loaded, saveEntry]);
+  }, [text, routineTicks, attachments, location, weather, inkUsed, loaded, saveEntry]);
 
   useEffect(() => {
     return () => {
@@ -133,7 +136,7 @@ export default function DatePage() {
     const over = text.split('\n').slice(28).join('\n');
     const newText = over ? `${mainVal}\n${over}` : mainVal;
     setText(newText);
-    updateEntry(ymdStr, { text: newText });
+    updateEntry(ymdStr, { text: newText, inkUsed: newText.length });
     if (!fetched && newText.trim() !== '') {
       setFetched(true);
       fetchMeta();
@@ -145,7 +148,7 @@ export default function DatePage() {
     const mainPart = text.split('\n').slice(0, 28).join('\n');
     const newText = overVal ? `${mainPart}\n${overVal}` : mainPart;
     setText(newText);
-    updateEntry(ymdStr, { text: newText });
+    updateEntry(ymdStr, { text: newText, inkUsed: newText.length });
     if (!fetched && newText.trim() !== '') {
       setFetched(true);
       fetchMeta();
@@ -158,11 +161,7 @@ export default function DatePage() {
 
   return (
     <div className="paper-page relative p-4">
-      <InkGauge
-        used={Math.min(lines.length, 28)}
-        total={28}
-        className="absolute right-2 top-2 w-20"
-      />
+      <InkGauge used={inkUsed} total={INK_TOTAL} className="absolute right-2 top-2 w-20" />
       <header className="mb-4">
         <div className="flex items-center gap-2 text-xl font-bold">
           <span>{displayDate(ymdStr)}</span>

--- a/web/src/state/useDiaryStore.ts
+++ b/web/src/state/useDiaryStore.ts
@@ -9,6 +9,7 @@ interface DiaryEntry {
   attachments: { name: string; uuid: string }[];
   loc?: { lat?: number; lon?: number; city?: string };
   weather?: { tmax?: number; tmin?: number; desc?: string };
+  inkUsed: number;
 }
 
 interface DiaryState {
@@ -46,19 +47,21 @@ export const useDiaryStore = create<DiaryState>((set, get) => ({
                 tmin: parsed.tmin as number | undefined,
               } as DiaryEntry['weather'])
             : undefined);
+        const text = (parsed.text as string) ?? '';
         const entry: DiaryEntry = {
-          text: (parsed.text as string) ?? '',
+          text,
           routineTicks: (parsed.routineTicks as RoutineItem[]) ?? parsed.routines ?? [],
           attachments: (parsed.attachments as { name: string; uuid: string }[]) ?? [],
           loc,
           weather,
+          inkUsed: (parsed.inkUsed as number) ?? text.length,
         };
         set((state) => ({ entries: { ...state.entries, [ymd]: entry } }));
       } else {
         const settings = await getSettings();
         const routineTicks =
           settings?.routineTemplate?.map((r) => ({ text: r.text, done: false })) ?? [];
-        const entry: DiaryEntry = { text: '', routineTicks, attachments: [] };
+        const entry: DiaryEntry = { text: '', routineTicks, attachments: [], inkUsed: 0 };
         set((state) => ({ entries: { ...state.entries, [ymd]: entry } }));
       }
     } catch (err) {


### PR DESCRIPTION
## Summary
- record ink usage on each diary entry
- compute character count on date page and update ink gauge accordingly

## Testing
- `npm test` *(fails: Executable doesn't exist at /root/.cache/ms-playwright/...)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bd79f679bc832b94bacb150469ec2c