### PR TITLE
Add IPv6 DNS record and weekly review infrastructure

### DIFF
--- a/infra/lib/app-stack.ts
+++ b/infra/lib/app-stack.ts
@@ -73,6 +73,12 @@ export class AppStack extends Stack {
       target: r53.RecordTarget.fromAlias(new targets.CloudFrontTarget(distro)),
     });
 
+    new r53.AaaaRecord(this, 'AliasAAAA', {
+      zone,
+      recordName: props.domain,
+      target: r53.RecordTarget.fromAlias(new targets.CloudFrontTarget(distro)),
+    });
+
     const userPool = new cognito.UserPool(this, 'UserPool', {
       selfSignUpEnabled: false,
     });

--- a/infra/lib/weekly-review-stack.ts
+++ b/infra/lib/weekly-review-stack.ts
@@ -1,0 +1,58 @@
+import {
+  Stack,
+  StackProps,
+  Duration,
+  aws_lambda as lambda,
+  aws_lambda_nodejs as lambdaNodejs,
+  aws_events as events,
+  aws_events_targets as targets,
+  aws_ssm as ssm,
+  aws_s3 as s3,
+} from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import * as iam from 'aws-cdk-lib/aws-iam';
+import * as path from 'path';
+
+interface WeeklyReviewStackProps extends StackProps {
+  bucket: s3.IBucket;
+}
+
+export class WeeklyReviewStack extends Stack {
+  constructor(scope: Construct, id: string, props: WeeklyReviewStackProps) {
+    super(scope, id, props);
+
+    const openAiParam = ssm.StringParameter.fromStringParameterName(
+      this,
+      'OpenAIKey',
+      'openai-key'
+    );
+
+    const fn = new lambdaNodejs.NodejsFunction(this, 'WeeklyReviewFunction', {
+      functionName: 'weekly-review',
+      entry: path.join(__dirname, '../functions/weekly-review.ts'),
+      handler: 'handler',
+      runtime: lambda.Runtime.NODEJS_20_X,
+      timeout: Duration.minutes(15),
+      environment: {
+        BUCKET_NAME: props.bucket.bucketName,
+        OPENAI_KEY_PARAM: openAiParam.parameterName,
+      },
+    });
+
+    props.bucket.grantReadWrite(fn);
+    openAiParam.grantRead(fn);
+
+    fn.addToRolePolicy(
+      new iam.PolicyStatement({
+        actions: ['ssm:GetParameter'],
+        resources: [openAiParam.parameterArn],
+      })
+    );
+
+    const rule = new events.Rule(this, 'WeeklyReviewSchedule', {
+      schedule: events.Schedule.cron({ weekDay: 'MON', hour: '0', minute: '0' }),
+    });
+
+    rule.addTarget(new targets.LambdaFunction(fn));
+  }
+}


### PR DESCRIPTION
## Summary
- route IPv6 traffic by adding an AAAA record alongside the existing A record
- add WeeklyReviewStack that defines a scheduled Lambda and required IAM access

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bd7d0c1cbc832baf61f492faa297d1