### PR TITLE
Schedule weekly review Lambda for Monday IST and expose function URL

### DIFF
--- a/infra/lib/weekly-review-stack.ts
+++ b/infra/lib/weekly-review-stack.ts
@@ -39,6 +39,8 @@ export class WeeklyReviewStack extends Stack {
       },
     });
 
+    fn.addFunctionUrl({ authType: lambda.FunctionUrlAuthType.AWS_IAM });
+
     props.bucket.grantReadWrite(fn);
     openAiParam.grantRead(fn);
 
@@ -50,7 +52,7 @@ export class WeeklyReviewStack extends Stack {
     );
 
     const rule = new events.Rule(this, 'WeeklyReviewSchedule', {
-      schedule: events.Schedule.cron({ weekDay: 'MON', hour: '0', minute: '0' }),
+      schedule: events.Schedule.cron({ weekDay: 'SUN', hour: '19', minute: '0' }),
     });
 
     rule.addTarget(new targets.LambdaFunction(fn));


### PR DESCRIPTION
## Summary
- adjust weekly review schedule to run Sundays at 19:00 UTC (00:30 IST Monday)
- expose Lambda via Function URL secured with AWS_IAM

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68bd84de64f0832bb4fa85193646ca31