### PR TITLE
Restrict object access to identity-specific prefix

### DIFF
--- a/infra/lib/app-stack.ts
+++ b/infra/lib/app-stack.ts
@@ -187,12 +187,11 @@ export class AppStack extends Stack {
     authRole.addToPolicy(
       new iam.PolicyStatement({
         actions: ['s3:GetObject', 's3:PutObject'],
-        resources: [userBucket.arnForObjects('*')],
-        conditions: {
-          StringLike: {
-            's3:prefix': 'private/${cognito-identity.amazonaws.com:sub}/*',
-          },
-        },
+        resources: [
+          userBucket.arnForObjects(
+            'private/${cognito-identity.amazonaws.com:sub}/*'
+          ),
+        ],
       })
     );
 


### PR DESCRIPTION
## Summary
- Limit authenticated users' S3 object access to their private subfolder
- Keep list permissions scoped to the same prefix

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bd88d56c74832ba4b97b9a1abaf670