### PR TITLE
test: add weekly review routine scenario

### DIFF
--- a/web/tests/routine.spec.ts
+++ b/web/tests/routine.spec.ts
@@ -19,3 +19,42 @@ test('add, toggle and remove routine items', async ({ page }) => {
   await page.getByRole('button', { name: '×' }).click();
   await expect(input).toHaveCount(0);
 });
+
+test('weekly review reflects routine completion and streak', async ({ page }) => {
+  // Calculate first three days of the current week (Monday as start).
+  const today = new Date();
+  const start = new Date(today);
+  const diff = (today.getDay() + 6) % 7;
+  start.setDate(today.getDate() - diff);
+  const ymd = (d: Date) => d.toLocaleDateString('en-CA');
+  const day1 = ymd(start);
+  const day2 = ymd(new Date(start.getTime() + 24 * 60 * 60 * 1000));
+  const day3 = ymd(new Date(start.getTime() + 2 * 24 * 60 * 60 * 1000));
+
+  const entries: Record<string, unknown> = {
+    [day1]: { routineTicks: [{ text: 'Exercise', done: false }] },
+    [day2]: { routineTicks: [{ text: 'Exercise', done: true }] },
+    [day3]: { routineTicks: [{ text: 'Exercise', done: true }] },
+  };
+
+  await page.route('**/entries/**', async (route) => {
+    const url = new URL(route.request().url());
+    const match = url.pathname.match(/entries\/(\d{4})\/(\d{2})\/(\d{2})\.json$/);
+    if (match) {
+      const key = `${match[1]}-${match[2]}-${match[3]}`;
+      const body = entries[key];
+      if (body) {
+        await route.fulfill({ status: 200, body: JSON.stringify(body) });
+      } else {
+        await route.fulfill({ status: 404, body: '' });
+      }
+      return;
+    }
+    await route.continue();
+  });
+
+  await page.goto('/weekly');
+  const item = page.getByRole('listitem').filter({ hasText: 'Exercise' });
+  await expect(item.getByText('2/3')).toBeVisible();
+  await expect(item.getByText('2d streak')).toBeVisible();
+});


### PR DESCRIPTION
## Summary
- add Playwright test covering routine completion across multiple days and weekly review streak display

## Testing
- `npm test` *(fails: Executable doesn't exist at /root/.cache/ms-playwright/...)*

------
https://chatgpt.com/codex/tasks/task_e_68bd8c387aec832b978dc4d1255fa5ef