### PR TITLE
Use Bedrock for weekly review and enforce token caps

### DIFF
--- a/infra/functions/weekly-review.ts
+++ b/infra/functions/weekly-review.ts
@@ -1,3 +1,8 @@
+import {
+  BedrockRuntimeClient,
+  InvokeModelCommand,
+} from '@aws-sdk/client-bedrock-runtime';
+
 export interface WeeklyReviewResult {
   connectorsDigest?: {
     meetingsHours: number;
@@ -7,13 +12,60 @@ export interface WeeklyReviewResult {
   aiSummary?: string;
 }
 
-export async function handler(): Promise<WeeklyReviewResult> {
+interface WeeklyReviewEvent {
+  userId: string;
+}
+
+const modelId = process.env.BEDROCK_MODEL_ID ?? '';
+const userTokenCap = parseInt(process.env.USER_TOKEN_CAP ?? '0');
+const summaryTokenLimit = parseInt(process.env.SUMMARY_TOKEN_LIMIT ?? '0');
+
+const client = new BedrockRuntimeClient({});
+const tokenUsage: Record<string, number> = {};
+
+function estimateTokens(text: string): number {
+  return Math.ceil(text.length / 4);
+}
+
+export async function handler(event: WeeklyReviewEvent): Promise<WeeklyReviewResult> {
+  const connectorsDigest = {
+    meetingsHours: 0,
+    topContacts: [],
+    photosCount: 0,
+  };
+
+  const used = tokenUsage[event.userId] ?? 0;
+  const prompt = 'Write a short summary of this week.';
+  const needed = estimateTokens(prompt) + summaryTokenLimit;
+
+  if (used + needed > userTokenCap) {
+    return { connectorsDigest };
+  }
+
+  const command = new InvokeModelCommand({
+    modelId,
+    contentType: 'application/json',
+    accept: 'application/json',
+    body: JSON.stringify({
+      anthropic_version: 'bedrock-2023-05-31',
+      messages: [
+        {
+          role: 'user',
+          content: [{ type: 'text', text: prompt }],
+        },
+      ],
+      max_tokens: summaryTokenLimit,
+    }),
+  });
+
+  const response = await client.send(command);
+  const completion = JSON.parse(new TextDecoder().decode(response.body));
+  const aiSummary = completion.output_text ?? '';
+
+  tokenUsage[event.userId] = used + needed;
+
   return {
-    connectorsDigest: {
-      meetingsHours: 0,
-      topContacts: [],
-      photosCount: 0,
-    },
-    aiSummary: '',
+    connectorsDigest,
+    aiSummary,
   };
 }


### PR DESCRIPTION
## Summary
- Replace OpenAI key wiring with Bedrock model access and token limit env vars in weekly review stack
- Call Bedrock from weekly review Lambda and enforce per-user token limits

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bd93fbb630832bb36457a130535ed4