### PR TITLE
Sort cached entries for search

### DIFF
--- a/web/src/lib/entryCache.ts
+++ b/web/src/lib/entryCache.ts
@@ -32,5 +32,5 @@ export async function getCachedEntries(
       results.push({ ymd: key, text });
     }
   }
-  return results;
+  return results.sort((a, b) => b.ymd.localeCompare(a.ymd));
 }

--- a/web/src/pages/SearchPage.tsx
+++ b/web/src/pages/SearchPage.tsx
@@ -27,7 +27,8 @@ export default function SearchPage() {
       keys: ['text', 'ymd'],
       threshold: 0.4,
     });
-    setResults(fuse.search(query).map((r) => r.item));
+    const matches = new Set(fuse.search(query).map((r) => r.item.ymd));
+    setResults(entries.filter((e) => matches.has(e.ymd)));
   }, [query, entries]);
 
   return (


### PR DESCRIPTION
## Summary
- sort cached entries in descending date order
- keep search results in cached order by filtering without resorting

## Testing
- `npm test` *(fails: browserType.launch: Executable doesn't exist - run `npx playwright install` but download failed: Domain forbidden)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bd958ef174832bbbd18a036f351f74