### PR TITLE
feat: add optional weekly review stack

### DIFF
--- a/packages/infra/bin/auto-diary.ts
+++ b/packages/infra/bin/auto-diary.ts
@@ -3,6 +3,7 @@ import 'source-map-support/register';
 import { App } from 'aws-cdk-lib';
 import { EdgeStack } from '../lib/edge-stack.js';
 import { AppStack } from '../lib/app-stack.js';
+import { WeeklyReviewStack } from '../lib/weekly-review-stack.js';
 
 const app = new App();
 const domain = app.node.tryGetContext('domain') || 'example.com';
@@ -10,8 +11,18 @@ const hostedZoneId = app.node.tryGetContext('hostedZoneId') || 'Z2ABCDEFG';
 
 const edge = new EdgeStack(app, 'EdgeStack', { domain });
 
-new AppStack(app, 'AppStack', {
+const appStack = new AppStack(app, 'AppStack', {
   domain,
   hostedZoneId,
   certArn: edge.certArn,
 });
+
+const deployWeeklyReview =
+  app.node.tryGetContext('deployWeeklyReview') === 'true' ||
+  process.env.DEPLOY_WEEKLY_REVIEW === 'true';
+
+if (deployWeeklyReview) {
+  new WeeklyReviewStack(app, 'WeeklyReviewStack', {
+    bucket: appStack.userBucket,
+  });
+}

--- a/packages/infra/lib/app-stack.ts
+++ b/packages/infra/lib/app-stack.ts
@@ -23,6 +23,7 @@ interface AppStackProps extends StackProps {
 }
 
 export class AppStack extends Stack {
+  public readonly userBucket: s3.Bucket;
   constructor(scope: Construct, id: string, props: AppStackProps) {
     super(scope, id, props);
 
@@ -43,6 +44,7 @@ export class AppStack extends Stack {
         },
       ],
     });
+    this.userBucket = userBucket;
 
     const distro = new cf.Distribution(this, 'Distribution', {
       defaultBehavior: {

--- a/packages/infra/lib/weekly-review-stack.ts
+++ b/packages/infra/lib/weekly-review-stack.ts
@@ -7,6 +7,7 @@ import {
   aws_events as events,
   aws_events_targets as targets,
   aws_s3 as s3,
+  CfnOutput,
 } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import * as iam from 'aws-cdk-lib/aws-iam';
@@ -37,7 +38,9 @@ export class WeeklyReviewStack extends Stack {
       },
     });
 
-    fn.addFunctionUrl({ authType: lambda.FunctionUrlAuthType.AWS_IAM });
+    const fnUrl = fn.addFunctionUrl({
+      authType: lambda.FunctionUrlAuthType.AWS_IAM,
+    });
 
     props.bucket.grantReadWrite(fn);
 
@@ -55,5 +58,7 @@ export class WeeklyReviewStack extends Stack {
     });
 
     rule.addTarget(new targets.LambdaFunction(fn));
+
+    new CfnOutput(this, 'WeeklyReviewFunctionUrl', { value: fnUrl.url });
   }
 }


### PR DESCRIPTION
## Summary
- expose userdata bucket from AppStack and instantiate WeeklyReviewStack after AppStack
- allow enabling WeeklyReviewStack via `deployWeeklyReview` context or env flag
- output weekly review function URL

## Testing
- `npm test` *(fails: 6 failing Playwright tests)*
- `npm run build` *(fails: web TypeScript errors)*
- `npm run build --workspace infra`


------
https://chatgpt.com/codex/tasks/task_e_68bda63351a0832b8e71a3dbe22f57bf