### PR TITLE
feat: add header with search and user menu

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -1,7 +1,7 @@
-import { BrowserRouter, Routes, Route, Navigate, Link } from 'react-router-dom';
+import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import { useAuth } from './state/useAuth';
-import { ThemeButton } from './components/ThemeButton';
 import { OfflineBanner } from './components/OfflineBanner';
+import { Header } from './components/Header';
 import CalendarPage from './pages/CalendarPage';
 import DatePage from './pages/DatePage';
 import SettingsPage from './pages/SettingsPage';
@@ -14,16 +14,7 @@ function Layout() {
   return (
     <div className="flex min-h-screen flex-col">
       <OfflineBanner />
-      <header className="flex items-center justify-between p-4">
-        <nav className="flex gap-4">
-          <Link to="/calendar">Calendar</Link>
-          <Link to="/search">Search</Link>
-          <Link to="/weekly">Weekly Review</Link>
-          <Link to="/connectors">Connectors</Link>
-          <Link to="/settings">Settings</Link>
-        </nav>
-        <ThemeButton />
-      </header>
+      <Header />
       <main className="flex-1 p-4">
         <Routes>
           <Route path="/" element={<Navigate to="/calendar" replace />} />

--- a/packages/web/src/components/Header.tsx
+++ b/packages/web/src/components/Header.tsx
@@ -1,0 +1,98 @@
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import Fuse from 'fuse.js';
+import { getCachedEntries } from '../lib/entryCache';
+import { displayDate } from '../lib/date';
+import { useAuth } from '../state/useAuth';
+import { ThemeButton } from './ThemeButton';
+
+const DEFAULT_DAYS = 30;
+
+export function Header() {
+  const { logout } = useAuth();
+  const [query, setQuery] = useState('');
+  const [entries, setEntries] = useState<{ ymd: string; text: string }[]>([]);
+  const [results, setResults] = useState<{ ymd: string; text: string }[]>([]);
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  useEffect(() => {
+    getCachedEntries(DEFAULT_DAYS).then((es) => {
+      setEntries(es);
+      setResults(es);
+    });
+  }, []);
+
+  useEffect(() => {
+    if (!query) {
+      setResults(entries);
+      return;
+    }
+    const fuse = new Fuse(entries, {
+      keys: ['text', 'ymd'],
+      threshold: 0.4,
+    });
+    const matches = new Set(fuse.search(query).map((r) => r.item.ymd));
+    setResults(entries.filter((e) => matches.has(e.ymd)));
+  }, [query, entries]);
+
+  return (
+    <header className="flex items-center justify-between p-4">
+      <nav className="flex gap-4">
+        <Link to="/calendar">Calendar</Link>
+        <Link to="/search">Search</Link>
+        <Link to="/weekly">Weekly Review</Link>
+        <Link to="/connectors">Connectors</Link>
+        <Link to="/settings">Settings</Link>
+      </nav>
+      <div className="flex items-center gap-2">
+        <div className="relative">
+          <input
+            className="rounded border px-2 py-1 dark:bg-gray-800"
+            placeholder="Search entries"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+          />
+          {results.length > 0 && (
+            <ul className="absolute right-0 mt-1 w-64 max-h-60 overflow-auto rounded border bg-white shadow dark:bg-gray-800">
+              {results.slice(0, 10).map((r) => (
+                <li key={r.ymd}>
+                  <Link
+                    to={`/date/${r.ymd}`}
+                    className="block px-2 py-1 hover:bg-gray-100 dark:hover:bg-gray-700"
+                    onClick={() => setQuery('')}
+                  >
+                    {displayDate(r.ymd)}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+        <ThemeButton />
+        <div className="relative">
+          <button
+            onClick={() => setMenuOpen(!menuOpen)}
+            className="rounded px-2 py-1 hover:bg-gray-200 dark:hover:bg-gray-700"
+            aria-haspopup="menu"
+            aria-expanded={menuOpen}
+          >
+            ☰
+          </button>
+          {menuOpen && (
+            <div className="absolute right-0 mt-2 w-32 rounded border bg-white shadow dark:bg-gray-800">
+              <button
+                onClick={() => {
+                  setMenuOpen(false);
+                  logout();
+                }}
+                className="block w-full px-4 py-2 text-left hover:bg-gray-100 dark:hover:bg-gray-700"
+              >
+                Sign out
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+    </header>
+  );
+}


### PR DESCRIPTION
## Summary
- add `Header` component with inline search, user menu, and theme toggle
- replace navigation links in `App.tsx` with the new header
- keep calendar as default landing page

## Testing
- `npm run lint --workspace packages/web`
- `npm test` *(fails: playwright browsers unavailable; 403 when trying to install)*


------
https://chatgpt.com/codex/tasks/task_e_68be36eb8880832bb04af1b6f8a4959d