### PR TITLE
feat: visualize daily ink density in calendar

### DIFF
--- a/packages/web/src/components/CalendarGrid.tsx
+++ b/packages/web/src/components/CalendarGrid.tsx
@@ -3,7 +3,7 @@ import { useMemo } from 'react';
 interface CalendarGridProps {
   year: number;
   month: number; // 1-based month
-  entries: string[]; // array of days like '01', '02'
+  entries: Record<string, number>; // map of day -> ink used/count
   today?: string; // 'YYYY-MM-DD'
   onSelect?: (ymd: string) => void;
 }
@@ -25,6 +25,10 @@ export function CalendarGrid({ year, month, entries, today, onSelect }: Calendar
   }, [year, month]);
 
   const monthStr = pad(month);
+  const maxCount = useMemo(() => {
+    const values = Object.values(entries);
+    return values.length ? Math.max(...values) : 0;
+  }, [entries]);
 
   return (
     <div className="grid grid-cols-7 gap-2">
@@ -35,7 +39,8 @@ export function CalendarGrid({ year, month, entries, today, onSelect }: Calendar
         const dayStr = pad(day);
         const ymd = `${year}-${monthStr}-${dayStr}`;
         const isToday = today === ymd;
-        const hasEntry = entries.includes(dayStr);
+        const count = entries[dayStr] ?? 0;
+        const ratio = maxCount ? count / maxCount : 0;
         return (
           <button
             key={idx}
@@ -45,7 +50,22 @@ export function CalendarGrid({ year, month, entries, today, onSelect }: Calendar
             }`}
           >
             <span>{day}</span>
-            {hasEntry && <span className="mt-1 h-1 w-1 rounded-full bg-blue-500" />}
+            {count > 0 && (
+              <div className="mt-1 flex w-full justify-center">
+                {count <= 3 ? (
+                  <div className="flex gap-0.5">
+                    {Array.from({ length: count }).map((_, i) => (
+                      <span key={i} className="h-1 w-1 rounded-full bg-blue-500" />
+                    ))}
+                  </div>
+                ) : (
+                  <span
+                    className="h-1 rounded-full bg-blue-500"
+                    style={{ width: `${ratio * 100}%`, opacity: 0.3 + 0.7 * ratio }}
+                  />
+                )}
+              </div>
+            )}
           </button>
         );
       })}

--- a/packages/web/src/pages/CalendarPage.tsx
+++ b/packages/web/src/pages/CalendarPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { CalendarGrid } from '../components/CalendarGrid';
-import { listMonth } from '../lib/s3Client';
+import { listMonth, getEntry } from '../lib/s3Client';
 import { downloadMonthJSON, downloadMonthMarkdown } from '../lib/export';
 import { useDiaryStore } from '../state/useDiaryStore';
 
@@ -14,13 +14,33 @@ export default function CalendarPage() {
   const today = new Date();
   const year = yyyy ? parseInt(yyyy, 10) : today.getFullYear();
   const month = mm ? parseInt(mm, 10) : today.getMonth() + 1;
-  const [entries, setEntries] = useState<string[]>([]);
+  const [entries, setEntries] = useState<Record<string, number>>({});
   const navigate = useNavigate();
   const setCurrentDate = useDiaryStore((s) => s.setCurrentDate);
   const loadEntry = useDiaryStore((s) => s.loadEntry);
 
   useEffect(() => {
-    listMonth(String(year), pad(month)).then(setEntries).catch(() => setEntries([]));
+    listMonth(String(year), pad(month))
+      .then(async (days) => {
+        const pairs = await Promise.all(
+          days.map(async (d) => {
+            const ymd = `${year}-${pad(month)}-${d}`;
+            try {
+              const raw = await getEntry(ymd);
+              if (raw) {
+                const parsed = JSON.parse(raw) as { inkUsed?: number; text?: string };
+                const ink = parsed.inkUsed ?? parsed.text?.length ?? 0;
+                return [d, ink] as [string, number];
+              }
+            } catch {
+              // ignore
+            }
+            return [d, 0] as [string, number];
+          })
+        );
+        setEntries(Object.fromEntries(pairs));
+      })
+      .catch(() => setEntries({}));
   }, [year, month]);
 
   const todayYmd = `${today.getFullYear()}-${pad(today.getMonth() + 1)}-${pad(today.getDate())}`;


### PR DESCRIPTION
## Summary
- show entry ink counts per day in calendar grid
- load monthly entries and compute ink totals in calendar page

## Testing
- `npm test` *(fails: playwright not found)*
- `npm run lint -w packages/web` *(fails: @eslint/js module missing)*
- `npm run build -w packages/web` *(fails: cannot find modules and implicit any types)*

------
https://chatgpt.com/codex/tasks/task_e_68be39702270832baa0b3918017adc3c