### PR TITLE
feat(infra): expose web bucket and distribution outputs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,7 +45,9 @@ jobs:
 
       - name: Deploy CDK stacks
         working-directory: packages/infra
-        run: npx cdk deploy --all --require-approval never -c domain=$DOMAIN_NAME -c hostedZoneId=$HOSTED_ZONE_ID -c deployWeeklyReview=$ENABLE_WEEKLY_LAMBDA --outputs-file cdk-outputs.json
+        run: |
+          rm -f cdk-outputs.json
+          npx cdk deploy --all --require-approval never -c domain=$DOMAIN_NAME -c hostedZoneId=$HOSTED_ZONE_ID -c deployWeeklyReview=$ENABLE_WEEKLY_LAMBDA --outputs-file cdk-outputs.json
 
       - name: Build web
         working-directory: packages/web

--- a/packages/infra/lib/app-stack.ts
+++ b/packages/infra/lib/app-stack.ts
@@ -222,6 +222,10 @@ export class AppStack extends Stack {
       value: distro.distributionDomainName,
     });
 
+    new CfnOutput(this, 'CloudFrontDistributionId', {
+      value: distro.distributionId,
+    });
+
     new CfnOutput(this, 'Domain', { value: props.domain });
 
     new CfnOutput(this, 'UserPoolId', { value: userPool.userPoolId });
@@ -231,6 +235,8 @@ export class AppStack extends Stack {
     });
 
     new CfnOutput(this, 'IdentityPoolId', { value: identityPool.ref });
+
+    new CfnOutput(this, 'WebBucketName', { value: webBucket.bucketName });
 
     new CfnOutput(this, 'UserdataBucketName', { value: userBucket.bucketName });
   }


### PR DESCRIPTION
## Summary
- expose CloudFront distribution ID and web bucket name from CDK stack
- regenerate cdk-outputs.json in deploy workflow and consume outputs for sync/invalidation

## Testing
- `npm test` *(fails: The following dependencies are imported but could not be resolved: @aws-sdk/lib-storage)*
- `npm --workspace packages/infra run build`


------
https://chatgpt.com/codex/tasks/task_e_68be3d6ec9f4832bbb37a6549d49906b