### PR TITLE
feat: allow specifying hosted zone name

### DIFF
--- a/packages/infra/bin/auto-diary.ts
+++ b/packages/infra/bin/auto-diary.ts
@@ -8,6 +8,7 @@ import { WeeklyReviewStack } from '../lib/weekly-review-stack.js';
 const app = new App();
 const domain = app.node.tryGetContext('domain') || 'example.com';
 const hostedZoneId = app.node.tryGetContext('hostedZoneId') || 'Z2ABCDEFG';
+const hostedZoneName = app.node.tryGetContext('hostedZoneName');
 
 const edge = new EdgeStack(app, 'EdgeStack', { domain });
 
@@ -15,6 +16,7 @@ const appStack = new AppStack(app, 'AppStack', {
   domain,
   hostedZoneId,
   certArn: edge.certArn,
+  hostedZoneName,
 });
 
 const deployWeeklyReview =

--- a/packages/infra/lib/app-stack.ts
+++ b/packages/infra/lib/app-stack.ts
@@ -20,6 +20,7 @@ interface AppStackProps extends StackProps {
   domain: string;
   hostedZoneId: string;
   certArn: string;
+  hostedZoneName?: string;
 }
 
 export class AppStack extends Stack {
@@ -67,9 +68,14 @@ export class AppStack extends Stack {
       domainNames: [props.domain, `www.${props.domain}`],
     });
 
+    const parts = props.domain.split('.');
+    const rootDomain =
+      props.hostedZoneName ||
+      (parts.length > 2 ? parts.slice(1).join('.') : props.domain);
+
     const zone = r53.HostedZone.fromHostedZoneAttributes(this, 'Zone', {
       hostedZoneId: props.hostedZoneId,
-      zoneName: props.domain,
+      zoneName: rootDomain,
     });
 
     new r53.ARecord(this, 'Alias', {


### PR DESCRIPTION
## Summary
- allow overriding hosted zone via new `hostedZoneName` prop
- derive root domain from `domain` when `hostedZoneName` not provided
- pass optional `hostedZoneName` from CDK app context

## Testing
- `npm test` *(fails: @aws-sdk/lib-storage missing in packages/web)*
- `npm run build --workspace infra`


------
https://chatgpt.com/codex/tasks/task_e_68be3f1e00d8832b86db996af14f0310