### PR TITLE
Summarize CloudFront URL in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -77,3 +77,8 @@ jobs:
         run: |
           DIST_ID=$(jq -r '.AppStack.CloudFrontDistributionId' packages/infra/cdk-outputs.json)
           aws cloudfront create-invalidation --distribution-id $DIST_ID --paths '/*'
+
+      - name: Add CloudFront URL to summary
+        run: |
+          DIST_URL=$(jq -r '.AppStack.CloudFrontDistributionUrl' packages/infra/cdk-outputs.json)
+          echo "CloudFront Distribution URL: $DIST_URL" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary
- add deploy step to write CloudFront Distribution URL to job summary

## Testing
- `npm test` *(fails: browserType.launch executable missing; suggests `npx playwright install`)*

------
https://chatgpt.com/codex/tasks/task_e_68be413adf84832b9f0a26dc71c902e8