### PR TITLE
Use CDK outputs to empty S3 buckets during destroy

### DIFF
--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -41,13 +41,10 @@ jobs:
 
       - name: Empty S3 buckets
         run: |
-          stacks=$(aws cloudformation list-stacks --stack-status-filter CREATE_COMPLETE UPDATE_COMPLETE UPDATE_ROLLBACK_COMPLETE --query 'StackSummaries[].StackName' --output text)
-          for stack in $stacks; do
-            buckets=$(aws cloudformation list-stack-resources --stack-name $stack --query "StackResourceSummaries[?ResourceType=='AWS::S3::Bucket'].PhysicalResourceId" --output text)
-            for bucket in $buckets; do
-              aws s3 rm "s3://$bucket" --recursive || true
-            done
-          done
+          WEB_BUCKET=$(jq -r '.AppStack.WebBucketName' packages/infra/cdk-outputs.json)
+          USER_BUCKET=$(jq -r '.AppStack.UserdataBucketName' packages/infra/cdk-outputs.json)
+          aws s3 rm "s3://$WEB_BUCKET" --recursive || true
+          aws s3 rm "s3://$USER_BUCKET" --recursive || true
 
       - name: Destroy CDK stacks
         working-directory: packages/infra


### PR DESCRIPTION
## Summary
- empty Web and userdata buckets using names from `cdk-outputs.json` before destroying stacks

## Testing
- `npm test` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1187/chrome-linux/headless_shell)*

------
https://chatgpt.com/codex/tasks/task_e_68be42314994832bb40e57c39e9813c2