### PR TITLE
feat: compute weekly habit stats

### DIFF
--- a/packages/infra/functions/weekly-review.ts
+++ b/packages/infra/functions/weekly-review.ts
@@ -2,8 +2,22 @@ import {
   BedrockRuntimeClient,
   InvokeModelCommand,
 } from '@aws-sdk/client-bedrock-runtime';
+import {
+  GetObjectCommand,
+  PutObjectCommand,
+  S3Client,
+} from '@aws-sdk/client-s3';
+
+interface HabitStat {
+  name: string;
+  done: number;
+  total: number;
+  streak: number;
+}
 
 export interface WeeklyReviewResult {
+  habits: HabitStat[];
+  suggestions: string[];
   connectorsDigest?: {
     meetingsHours: number;
     topContacts: string[];
@@ -19,53 +33,172 @@ interface WeeklyReviewEvent {
 const modelId = process.env.BEDROCK_MODEL_ID ?? '';
 const userTokenCap = parseInt(process.env.USER_TOKEN_CAP ?? '0');
 const summaryTokenLimit = parseInt(process.env.SUMMARY_TOKEN_LIMIT ?? '0');
+const bucketName = process.env.BUCKET_NAME ?? '';
 
 const client = new BedrockRuntimeClient({});
+const s3 = new S3Client({});
 const tokenUsage: Record<string, number> = {};
 
 function estimateTokens(text: string): number {
   return Math.ceil(text.length / 4);
 }
 
+function startOfWeek(date: Date): Date {
+  const d = new Date(date);
+  const diff = (d.getDay() + 6) % 7; // Monday start
+  d.setDate(d.getDate() - diff);
+  d.setHours(0, 0, 0, 0);
+  return d;
+}
+
+function getIsoWeek(date: Date): number {
+  const d = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
+  const dayNum = d.getUTCDay() || 7;
+  d.setUTCDate(d.getUTCDate() + 4 - dayNum);
+  const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
+  return Math.ceil(((d.getTime() - yearStart.getTime()) / 86400000 + 1) / 7);
+}
+
+function formatYmd(d: Date): string {
+  const yyyy = d.getFullYear().toString();
+  const mm = (d.getMonth() + 1).toString().padStart(2, '0');
+  const dd = d.getDate().toString().padStart(2, '0');
+  return `${yyyy}-${mm}-${dd}`;
+}
+
 export async function handler(event: WeeklyReviewEvent): Promise<WeeklyReviewResult> {
-  const connectorsDigest = {
-    meetingsHours: 0,
-    topContacts: [],
-    photosCount: 0,
-  };
+  const start = startOfWeek(new Date());
+  const ymds: string[] = [];
+  for (let i = 0; i < 7; i++) {
+    const d = new Date(start);
+    d.setDate(start.getDate() + i);
+    ymds.push(formatYmd(d));
+  }
+
+  const entries: Record<string, unknown>[] = [];
+  for (const ymd of ymds) {
+    const [yyyy, mm, dd] = ymd.split('-');
+    const key = `${event.userId}/entries/${yyyy}/${mm}/${dd}.json`;
+    try {
+      const obj = await s3.send(
+        new GetObjectCommand({ Bucket: bucketName, Key: key })
+      );
+      const body = await obj.Body?.transformToString();
+      if (body) entries.push(JSON.parse(body));
+      else entries.push({});
+    } catch {
+      entries.push({});
+    }
+  }
+
+  const map = new Map<string, { done: number; total: number; streak: number }>();
+  const streak = new Map<string, number>();
+  for (let i = 0; i < entries.length; i++) {
+    const entry = entries[i];
+    const routines: { text: string; done: boolean }[] =
+      (entry as {
+        routineTicks?: { text: string; done: boolean }[];
+        routines?: { text: string; done: boolean }[];
+      }).routineTicks ?? (entry as { routines?: { text: string; done: boolean }[] }).routines ?? [];
+    const todays = new Set<string>();
+    for (const r of routines) {
+      const s =
+        map.get(r.text) ?? { done: 0, total: 0, streak: 0 };
+      s.total += 1;
+      if (r.done) {
+        s.done += 1;
+        const cur = (streak.get(r.text) ?? 0) + 1;
+        streak.set(r.text, cur);
+        s.streak = cur;
+      } else {
+        streak.set(r.text, 0);
+        s.streak = 0;
+      }
+      map.set(r.text, s);
+      todays.add(r.text);
+    }
+    for (const name of streak.keys()) {
+      if (!todays.has(name)) {
+        streak.set(name, 0);
+        const s = map.get(name);
+        if (s) s.streak = 0;
+      }
+    }
+  }
+
+  const habits: HabitStat[] = Array.from(map.entries()).map(([name, v]) => ({
+    name,
+    done: v.done,
+    total: v.total,
+    streak: v.streak,
+  }));
+
+  const suggestions = habits
+    .filter((h) => h.total > 0 && h.done / h.total < 0.6)
+    .sort((a, b) => a.done / a.total - b.done / b.total)
+    .slice(0, 3)
+    .map((h) => `Focus more on ${h.name} (only ${h.done}/${h.total}).`);
+
+  let connectorsDigest: WeeklyReviewResult['connectorsDigest'];
+  try {
+    const obj = await s3.send(
+      new GetObjectCommand({
+        Bucket: bucketName,
+        Key: `${event.userId}/connectors/summary.json`,
+      })
+    );
+    const body = await obj.Body?.transformToString();
+    if (body) connectorsDigest = JSON.parse(body);
+  } catch {
+    // ignore if missing
+  }
 
   const used = tokenUsage[event.userId] ?? 0;
   const prompt = 'Write a short summary of this week.';
   const needed = estimateTokens(prompt) + summaryTokenLimit;
 
-  if (used + needed > userTokenCap) {
-    return { connectorsDigest };
+  let aiSummary: string | undefined;
+  if (used + needed <= userTokenCap) {
+    const command = new InvokeModelCommand({
+      modelId,
+      contentType: 'application/json',
+      accept: 'application/json',
+      body: JSON.stringify({
+        anthropic_version: 'bedrock-2023-05-31',
+        messages: [
+          {
+            role: 'user',
+            content: [{ type: 'text', text: prompt }],
+          },
+        ],
+        max_tokens: summaryTokenLimit,
+      }),
+    });
+
+    const response = await client.send(command);
+    const completion = JSON.parse(new TextDecoder().decode(response.body));
+    aiSummary = completion.output_text ?? '';
+    tokenUsage[event.userId] = used + needed;
   }
 
-  const command = new InvokeModelCommand({
-    modelId,
-    contentType: 'application/json',
-    accept: 'application/json',
-    body: JSON.stringify({
-      anthropic_version: 'bedrock-2023-05-31',
-      messages: [
-        {
-          role: 'user',
-          content: [{ type: 'text', text: prompt }],
-        },
-      ],
-      max_tokens: summaryTokenLimit,
-    }),
-  });
-
-  const response = await client.send(command);
-  const completion = JSON.parse(new TextDecoder().decode(response.body));
-  const aiSummary = completion.output_text ?? '';
-
-  tokenUsage[event.userId] = used + needed;
-
-  return {
-    connectorsDigest,
-    aiSummary,
+  const yyyy = start.getFullYear().toString();
+  const ww = getIsoWeek(start).toString().padStart(2, '0');
+  const weeklyKey = `${event.userId}/weekly/${yyyy}-${ww}.json`;
+  const result: WeeklyReviewResult = {
+    habits,
+    suggestions,
+    ...(connectorsDigest ? { connectorsDigest } : {}),
+    ...(aiSummary ? { aiSummary } : {}),
   };
+
+  await s3.send(
+    new PutObjectCommand({
+      Bucket: bucketName,
+      Key: weeklyKey,
+      Body: JSON.stringify(result),
+      ContentType: 'application/json',
+    })
+  );
+
+  return result;
 }

--- a/packages/infra/lib/weekly-review-stack.ts
+++ b/packages/infra/lib/weekly-review-stack.ts
@@ -42,7 +42,9 @@ export class WeeklyReviewStack extends Stack {
       authType: lambda.FunctionUrlAuthType.AWS_IAM,
     });
 
-    props.bucket.grantReadWrite(fn);
+    props.bucket.grantRead(fn, '*/entries/*');
+    props.bucket.grantRead(fn, '*/connectors/*');
+    props.bucket.grantReadWrite(fn, '*/weekly/*');
 
     fn.addToRolePolicy(
       new iam.PolicyStatement({

--- a/packages/infra/package.json
+++ b/packages/infra/package.json
@@ -7,11 +7,12 @@
     "cdk": "cdk"
   },
   "devDependencies": {
-    "typescript": "^5.4.0",
+    "aws-cdk": "^2.158.0",
     "ts-node": "^10.9.1",
-    "aws-cdk": "^2.158.0"
+    "typescript": "^5.4.0"
   },
   "dependencies": {
+    "@aws-sdk/client-s3": "^3.883.0",
     "aws-cdk-lib": "^2.158.0",
     "constructs": "^10.3.0"
   }

--- a/packages/web/src/lib/s3Client.ts
+++ b/packages/web/src/lib/s3Client.ts
@@ -120,6 +120,8 @@ export interface Settings {
 }
 
 export interface WeeklyData {
+  habits?: { name: string; done: number; total: number; streak: number }[];
+  suggestions?: string[];
   connectorsDigest?: {
     meetingsHours: number;
     topContacts: string[];
@@ -211,18 +213,12 @@ export async function getWeekly(
     );
     const body = await new Response(res.Body as ReadableStream).text();
     if (res.ETag) await setEtag(key, res.ETag);
-    const parsed = JSON.parse(body) as {
-      connectorsDigest?: {
-        meetingsHours: number;
-        topContacts: string[];
-        photosCount: number;
-      };
-      aiSummary?: string;
-      summary?: string;
-    };
+    const parsed = JSON.parse(body) as WeeklyData & { summary?: string };
     return {
       connectorsDigest: parsed.connectorsDigest,
       aiSummary: parsed.aiSummary ?? parsed.summary,
+      habits: parsed.habits,
+      suggestions: parsed.suggestions,
     };
   } catch (err) {
     const status = (err as { $metadata?: { httpStatusCode?: number } }).$metadata


### PR DESCRIPTION
## Summary
- analyze past week's entries from S3 to compute habit stats and improvement tips
- write weekly summaries back to S3 and optionally include connector digests and AI recap
- limit bucket access to entries and weekly prefixes for the weekly review function

## Testing
- `yarn test` *(fails: Failed to resolve import "@aws-sdk/lib-storage"; Playwright tests not fully configured)*

------
https://chatgpt.com/codex/tasks/task_e_68be4650d57c832b86619381cb7a5166