### PR TITLE
Expose Cognito Hosted UI domain output

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,13 +58,14 @@ jobs:
           USER_POOL_ID=$(jq -r '.AppStack.UserPoolId' ../infra/cdk-outputs.json)
           USER_POOL_CLIENT_ID=$(jq -r '.AppStack.UserPoolClientId' ../infra/cdk-outputs.json)
           IDENTITY_POOL_ID=$(jq -r '.AppStack.IdentityPoolId' ../infra/cdk-outputs.json)
+          HOSTED_UI_DOMAIN=$(jq -r '.AppStack.HostedUiDomain' ../infra/cdk-outputs.json)
           ENTRY_BUCKET=$(jq -r '.AppStack.UserdataBucketName' ../infra/cdk-outputs.json | tr '.' '-')
           VITE_REGION=$AWS_REGION \
           VITE_DOMAIN=$DOMAIN \
           VITE_USER_POOL_ID=$USER_POOL_ID \
           VITE_USER_POOL_CLIENT_ID=$USER_POOL_CLIENT_ID \
           VITE_IDENTITY_POOL_ID=$IDENTITY_POOL_ID \
-          VITE_HOSTED_UI_DOMAIN=$DOMAIN \
+          VITE_HOSTED_UI_DOMAIN=$HOSTED_UI_DOMAIN \
           VITE_ENTRY_BUCKET=$ENTRY_BUCKET \
           yarn build
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ flowchart TD
 | `VITE_USER_POOL_ID` | Cognito user pool id |
 | `VITE_USER_POOL_CLIENT_ID` | Cognito app client id |
 | `VITE_IDENTITY_POOL_ID` | Cognito identity pool id |
-| `VITE_HOSTED_UI_DOMAIN` | Cognito hosted UI domain |
+| `VITE_HOSTED_UI_DOMAIN` | Cognito hosted UI domain (from `HostedUiDomain` stack output) |
 | `VITE_ENTRY_BUCKET` | S3 bucket for journal entries |
 | `VITE_TEST_MODE` | Set to `true` to enable test fixtures |
 
@@ -86,7 +86,7 @@ CDK workflows also expect repository variables `AWS_ACCOUNT_ID`, `AWS_REGION`, `
    yarn install
    ```
 
-2. Create `packages/web/.env` and define the `VITE_*` variables listed above.
+2. Create `packages/web/.env` and define the `VITE_*` variables listed above (use the `HostedUiDomain` stack output for `VITE_HOSTED_UI_DOMAIN`).
 
 3. Start the web application:
 

--- a/packages/infra/lib/app-stack.ts
+++ b/packages/infra/lib/app-stack.ts
@@ -96,6 +96,12 @@ export class AppStack extends Stack {
       selfSignUpEnabled: false,
     });
 
+    const userPoolDomain = userPool.addDomain('HostedUiDomain', {
+      cognitoDomain: {
+        domainPrefix: `autodiary-${sanitizedDomain}`,
+      },
+    });
+
     const googleClientId = ssm.StringParameter.valueForStringParameter(
       this,
       'google-client-id'
@@ -243,6 +249,10 @@ export class AppStack extends Stack {
 
     new CfnOutput(this, 'UserPoolClientId', {
       value: userPoolClient.userPoolClientId,
+    });
+
+    new CfnOutput(this, 'HostedUiDomain', {
+      value: userPoolDomain.domainName,
     });
 
     new CfnOutput(this, 'IdentityPoolId', { value: identityPool.ref });

--- a/packages/web/playwright.config.ts
+++ b/packages/web/playwright.config.ts
@@ -25,7 +25,7 @@ export default defineConfig({
       VITE_USER_POOL_ID: 'pool',
       VITE_USER_POOL_CLIENT_ID: 'client',
       VITE_IDENTITY_POOL_ID: 'identity',
-      VITE_HOSTED_UI_DOMAIN: 'example.com',
+      VITE_HOSTED_UI_DOMAIN: 'auth.example.com',
       VITE_ENTRY_BUCKET: 'bucket',
       VITE_TEST_MODE: 'true',
     },


### PR DESCRIPTION
## Summary
- provision a Cognito hosted UI domain and surface it as a `HostedUiDomain` stack output
- use the new stack output in the deploy workflow to set `VITE_HOSTED_UI_DOMAIN`
- document how to obtain the hosted UI domain and update test config placeholder

## Testing
- `yarn test` *(fails: Failed to resolve import "@aws-sdk/lib-storage" and Playwright browsers missing)*
- `yarn build` *(fails: Cannot find name 'process'; missing Node type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_68be53248adc832b8d966046b69e3066