### PR TITLE
Enable routine editing for any date

### DIFF
--- a/packages/web/src/pages/DatePage.tsx
+++ b/packages/web/src/pages/DatePage.tsx
@@ -239,8 +239,8 @@ export default function DatePage() {
         onChange={(items) => {
           setRoutineTicks(items);
           updateEntry(ymdStr, { routineTicks: items });
+          void saveEntry();
         }}
-        editable={ymdStr === todayYmd}
       />
 
       <textarea


### PR DESCRIPTION
## Summary
- Allow editing routines on any selected day
- Save routine changes to the current date's entry

## Testing
- `yarn test` *(fails: Failed to resolve @aws-sdk/lib-storage; Playwright browsers missing)*

------
https://chatgpt.com/codex/tasks/task_e_68be572a21e4832b9909e51e88998f52