### PR TITLE
Expose AI provider settings for weekly review

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,6 +20,10 @@ jobs:
       DOMAIN_NAME: ${{ vars.DOMAIN_NAME }}
       HOSTED_ZONE_ID: ${{ vars.HOSTED_ZONE_ID }}
       ENABLE_WEEKLY_LAMBDA: ${{ vars.ENABLE_WEEKLY_LAMBDA }}
+      BEDROCK_TOKEN_CAP: ${{ vars.BEDROCK_TOKEN_CAP }}
+      BEDROCK_COST_CAP: ${{ vars.BEDROCK_COST_CAP }}
+      BEDROCK_COST_PER_1K: ${{ vars.BEDROCK_COST_PER_1K }}
+      AI_PROVIDER: ${{ vars.AI_PROVIDER }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -47,7 +51,7 @@ jobs:
         working-directory: packages/infra
         run: |
           rm -f cdk-outputs.json
-          yarn cdk deploy --all --require-approval never -c domain=$DOMAIN_NAME -c hostedZoneId=$HOSTED_ZONE_ID -c deployWeeklyReview=$ENABLE_WEEKLY_LAMBDA --outputs-file cdk-outputs.json
+          yarn cdk deploy --all --require-approval never -c domain=$DOMAIN_NAME -c hostedZoneId=$HOSTED_ZONE_ID -c deployWeeklyReview=$ENABLE_WEEKLY_LAMBDA -c bedrockTokenCap=$BEDROCK_TOKEN_CAP -c bedrockCostCap=$BEDROCK_COST_CAP -c bedrockCostPer1k=$BEDROCK_COST_PER_1K -c aiProvider=$AI_PROVIDER --outputs-file cdk-outputs.json
 
       - name: Build web
         working-directory: packages/web

--- a/packages/infra/functions/weekly-review.ts
+++ b/packages/infra/functions/weekly-review.ts
@@ -41,7 +41,7 @@ const aiProvider = (process.env.AI_PROVIDER ?? 'bedrock') as
 
 const providerConfigs = {
   bedrock: {
-    modelId: process.env.BEDROCK_MODEL_ID ?? '',
+    modelId: process.env.BEDROCK_MODEL_ID ?? 'anthropic.claude-v2',
     tokenCap: parseInt(process.env.BEDROCK_TOKEN_CAP ?? '0', 10),
     summaryTokenLimit: parseInt(
       process.env.BEDROCK_SUMMARY_TOKEN_LIMIT ?? '0',

--- a/packages/infra/lib/weekly-review-stack.ts
+++ b/packages/infra/lib/weekly-review-stack.ts
@@ -35,10 +35,31 @@ export class WeeklyReviewStack extends Stack {
       timeout: Duration.minutes(15),
       environment: {
         BUCKET_NAME: props.bucket.bucketName,
-        BEDROCK_MODEL_ID: 'anthropic.claude-v2',
-        USER_TOKEN_CAP: '10000',
-        SUMMARY_TOKEN_LIMIT: '1000',
+        BEDROCK_MODEL_ID:
+          this.node.tryGetContext('bedrockModelId') ||
+          process.env.BEDROCK_MODEL_ID ||
+          'anthropic.claude-v2',
+        BEDROCK_TOKEN_CAP:
+          this.node.tryGetContext('bedrockTokenCap') ||
+          process.env.BEDROCK_TOKEN_CAP ||
+          '10000',
+        BEDROCK_SUMMARY_TOKEN_LIMIT:
+          this.node.tryGetContext('bedrockSummaryTokenLimit') ||
+          process.env.BEDROCK_SUMMARY_TOKEN_LIMIT ||
+          '1000',
+        BEDROCK_COST_CAP:
+          this.node.tryGetContext('bedrockCostCap') ||
+          process.env.BEDROCK_COST_CAP ||
+          '0',
+        BEDROCK_COST_PER_1K:
+          this.node.tryGetContext('bedrockCostPer1k') ||
+          process.env.BEDROCK_COST_PER_1K ||
+          '0',
         TOKEN_TABLE_NAME: tokenTable.tableName,
+        AI_PROVIDER:
+          this.node.tryGetContext('aiProvider') ||
+          process.env.AI_PROVIDER ||
+          'bedrock',
       },
     });
 

--- a/packages/infra/tsconfig.json
+++ b/packages/infra/tsconfig.json
@@ -6,7 +6,8 @@
     "strict": true,
     "esModuleInterop": true,
     "outDir": "dist",
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "types": ["node"]
   },
   "include": ["bin", "lib"]
 }


### PR DESCRIPTION
## Summary
- allow weekly review stack to accept AI provider and Bedrock token/cost limits
- propagate AI variables through workflow
- default weekly review to Bedrock model `anthropic.claude-v2`

## Testing
- `yarn test` *(fails: Playwright browser download 403)*
- `npm --prefix packages/infra run build`


------
https://chatgpt.com/codex/tasks/task_e_68be5a991a34832b951099b37fc296bd