### PR TITLE
chore: regenerate outputs before bucket cleanup

### DIFF
--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -39,12 +39,20 @@ jobs:
       - name: Build
         run: yarn build
 
+      - name: Generate CDK outputs
+        run: yarn workspace infra cdk synth
+        continue-on-error: true
+
       - name: Empty S3 buckets
         run: |
-          WEB_BUCKET=$(jq -r '.AppStack.WebBucketName' packages/infra/cdk-outputs.json | tr '.' '-')
-          USER_BUCKET=$(jq -r '.AppStack.UserdataBucketName' packages/infra/cdk-outputs.json | tr '.' '-')
-          aws s3 rm "s3://$WEB_BUCKET" --recursive || true
-          aws s3 rm "s3://$USER_BUCKET" --recursive || true
+          if [ -f packages/infra/cdk-outputs.json ]; then
+            WEB_BUCKET=$(jq -r '.AppStack.WebBucketName' packages/infra/cdk-outputs.json | tr '.' '-')
+            USER_BUCKET=$(jq -r '.AppStack.UserdataBucketName' packages/infra/cdk-outputs.json | tr '.' '-')
+            aws s3 rm "s3://$WEB_BUCKET" --recursive || true
+            aws s3 rm "s3://$USER_BUCKET" --recursive || true
+          else
+            echo "cdk-outputs.json not found. Skipping bucket cleanup."
+          fi
 
       - name: Destroy CDK stacks
         working-directory: packages/infra


### PR DESCRIPTION
## Summary
- regenerate `cdk-outputs.json` before destroying infrastructure
- skip bucket cleanup gracefully when `cdk-outputs.json` is missing

## Testing
- `yarn test` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/...)*
- `npx playwright install` *(fails: Download failed: server returned code 403 body 'Domain forbidden')*


------
https://chatgpt.com/codex/tasks/task_e_68be5c8a77f0832bb1cc8d3acc391996