### PR TITLE
Allow weekly review Lambda to list bucket contents

### DIFF
--- a/packages/infra/lib/weekly-review-stack.ts
+++ b/packages/infra/lib/weekly-review-stack.ts
@@ -63,15 +63,17 @@ export class WeeklyReviewStack extends Stack {
       },
     });
 
-    const fnUrl = fn.addFunctionUrl({
-      authType: lambda.FunctionUrlAuthType.AWS_IAM,
-    });
-
+    // Allow listing of objects under the private/ prefix
+    props.bucket.grantRead(fn);
     props.bucket.grantRead(fn, 'private/*/entries/*');
     props.bucket.grantRead(fn, 'private/*/connectors/*');
     props.bucket.grantReadWrite(fn, 'private/*/weekly/*');
 
     tokenTable.grantReadWriteData(fn);
+
+    const fnUrl = fn.addFunctionUrl({
+      authType: lambda.FunctionUrlAuthType.AWS_IAM,
+    });
 
     fn.addToRolePolicy(
       new iam.PolicyStatement({


### PR DESCRIPTION
## Summary
- Grant unprefixed S3 read access so weekly-review Lambda can list `private/` objects
- Ensure permissions are attached before function URL and scheduling

## Testing
- `yarn test` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1187/chrome-linux/headless_shell)*

------
https://chatgpt.com/codex/tasks/task_e_68be5e24d2b4832ba1cf623d880b9c38