### PR TITLE
Allow DELETE in user bucket CORS

### DIFF
--- a/packages/infra/lib/app-stack.ts
+++ b/packages/infra/lib/app-stack.ts
@@ -41,7 +41,12 @@ export class AppStack extends Stack {
       versioned: true,
       cors: [
         {
-          allowedMethods: [s3.HttpMethods.GET, s3.HttpMethods.PUT, s3.HttpMethods.HEAD],
+          allowedMethods: [
+            s3.HttpMethods.GET,
+            s3.HttpMethods.PUT,
+            s3.HttpMethods.HEAD,
+            s3.HttpMethods.DELETE,
+          ],
           allowedOrigins: [
             `https://${props.domain}`,
             `https://www.${props.domain}`,


### PR DESCRIPTION
## Summary
- allow clients to perform DELETE requests on user S3 bucket by extending CORS configuration

## Testing
- `npx -w packages/infra tsc`
- `yarn test` *(fails: Looks like Playwright Test or Playwright was just installed or updated. Please run the following command to download new browsers: yarn playwright install)*
- `yarn --cwd packages/infra cdk deploy --app "npx ts-node --esm bin/auto-diary.ts"` *(fails: Unknown file extension ".ts" for bin/auto-diary.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68be625bc6e8832b800d39d4a2dd7f2c