### PR TITLE
Restrict weekly review S3 permissions

### DIFF
--- a/packages/infra/lib/weekly-review-stack.ts
+++ b/packages/infra/lib/weekly-review-stack.ts
@@ -67,10 +67,19 @@ export class WeeklyReviewStack extends Stack {
       },
     });
 
-    // Allow listing of objects under the private/ prefix
-    props.bucket.grantRead(fn);
-    props.bucket.grantRead(fn, 'private/*/entries/*');
-    props.bucket.grantRead(fn, 'private/*/connectors/*');
+    // Allow listing and reading objects only under the private/ prefix
+    fn.addToRolePolicy(
+      new iam.PolicyStatement({
+        actions: ['s3:ListBucket', 's3:GetObject'],
+        resources: [
+          props.bucket.bucketArn,
+          props.bucket.arnForObjects('private/*'),
+        ],
+        conditions: {
+          StringLike: { 's3:prefix': ['private/*'] },
+        },
+      })
+    );
     props.bucket.grantReadWrite(fn, 'private/*/weekly/*');
 
     tokenTable.grantReadWriteData(fn);


### PR DESCRIPTION
## Summary
- replace bucket.grantRead with explicit policy statement limiting S3 access to `private/*`
- retain read/write access to `private/*/weekly/*`

## Testing
- `yarn test` *(fails: Playwright browsers not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68be63b01bb4832bba6d84e1206062ad