### PR TITLE
feat: add www domain DNS records

### DIFF
--- a/packages/infra/lib/app-stack.ts
+++ b/packages/infra/lib/app-stack.ts
@@ -97,6 +97,18 @@ export class AppStack extends Stack {
       target: r53.RecordTarget.fromAlias(new targets.CloudFrontTarget(distro)),
     });
 
+    new r53.ARecord(this, 'AliasWWW', {
+      zone,
+      recordName: `www.${props.domain}`,
+      target: r53.RecordTarget.fromAlias(new targets.CloudFrontTarget(distro)),
+    });
+
+    new r53.AaaaRecord(this, 'AliasAAAAWWW', {
+      zone,
+      recordName: `www.${props.domain}`,
+      target: r53.RecordTarget.fromAlias(new targets.CloudFrontTarget(distro)),
+    });
+
     const userPool = new cognito.UserPool(this, 'UserPool', {
       selfSignUpEnabled: false,
     });


### PR DESCRIPTION
## Summary
- point www domain to CloudFront with A and AAAA records

## Testing
- `yarn test` *(fails: dependency resolution and Playwright browsers missing)*
- `yarn workspace infra cdk deploy --app "node --loader ts-node/esm bin/auto-diary.ts"` *(fails: cannot find package 'source-map-support')*


------
https://chatgpt.com/codex/tasks/task_e_68be67765dac832ba9d5730d687b9078