### PR TITLE
Parallelize month entry retrieval

### DIFF
--- a/packages/web/src/lib/export.ts
+++ b/packages/web/src/lib/export.ts
@@ -2,10 +2,19 @@ import { listMonth, getEntry } from './s3Client';
 
 async function gatherMonth(yyyy: string, mm: string) {
   const days = await listMonth(yyyy, mm);
+  const results = await Promise.all(
+    days.map(async (dd) => {
+      const ymd = `${yyyy}-${mm}-${dd}`;
+      try {
+        const body = await getEntry(ymd);
+        return { ymd, body };
+      } catch {
+        return { ymd, body: null };
+      }
+    })
+  );
   const entries: Record<string, unknown> = {};
-  for (const dd of days) {
-    const ymd = `${yyyy}-${mm}-${dd}`;
-    const body = await getEntry(ymd);
+  for (const { ymd, body } of results) {
     if (body) {
       try {
         entries[ymd] = JSON.parse(body);


### PR DESCRIPTION
## Summary
- gatherMonth now fetches daily entries concurrently via Promise.all
- maintains chronological ordering and ignores failed fetches gracefully

## Testing
- `yarn test` *(fails: Playwright browsers need installation)*

------
https://chatgpt.com/codex/tasks/task_e_68be8048a558832b894d8a57f8362229