### PR TITLE
feat: add TTL to weekly review tokens table

### DIFF
--- a/packages/infra/functions/weekly-review.ts
+++ b/packages/infra/functions/weekly-review.ts
@@ -173,6 +173,11 @@ async function checkAndConsumeUsage(
   if (tokens + neededTokens > tokenCap || cost + neededCost > costCap)
     return false;
 
+  const ttlSeconds = 90 * 24 * 60 * 60;
+  const expireAt = Math.floor(
+    new Date(`${weekStart}T00:00:00Z`).getTime() / 1000 + ttlSeconds
+  );
+
   await dynamo.send(
     new PutItemCommand({
       TableName: tokenTableName,
@@ -181,6 +186,7 @@ async function checkAndConsumeUsage(
         weekStart: { S: weekStart },
         tokens: { N: String(tokens + neededTokens) },
         cost: { N: String(cost + neededCost) },
+        expireAt: { N: String(expireAt) },
       },
     })
   );

--- a/packages/infra/lib/weekly-review-stack.ts
+++ b/packages/infra/lib/weekly-review-stack.ts
@@ -35,6 +35,7 @@ export class WeeklyReviewStack extends Stack {
     const tokenTable = new dynamodb.Table(this, 'WeeklyReviewTokens', {
       partitionKey: { name: 'userId', type: dynamodb.AttributeType.STRING },
       billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+      timeToLiveAttribute: 'expireAt',
     });
 
     const environment: Record<string, string> = {


### PR DESCRIPTION
## Summary
- add TTL attribute to WeeklyReviewTokens table
- store expiration timestamp when recording token usage

## Testing
- `yarn test` *(fails: tests/diary.spec.ts:15:1 › overflow textarea receives extra lines, tests/diary.spec.ts:25:1 › Next button moves to following day, tests/routine.spec.ts:7:1 › add, toggle and remove routine items, tests/routine.spec.ts:23:1 › weekly review reflects routine completion and streak, tests/theme.spec.ts:5:1 › cycles through available themes, tests/weekly.spec.ts:15:1 › weekly review shows habit stats, streaks and suggestions)*

------
https://chatgpt.com/codex/tasks/task_e_68be8ca93a20832ba694ed34bf7dee93