### PR TITLE
feat(web): show calendar density from counts or ink

### DIFF
--- a/packages/web/src/pages/CalendarPage.tsx
+++ b/packages/web/src/pages/CalendarPage.tsx
@@ -13,15 +13,15 @@ export default function CalendarPage() {
   const today = new Date();
   const year = yyyy ? parseInt(yyyy, 10) : today.getFullYear();
   const month = mm ? parseInt(mm, 10) : today.getMonth() + 1;
-  const [entries, setEntries] = useState<Record<string, number>>({});
+  const [inkTotals, setInkTotals] = useState<Record<string, number>>({});
   const navigate = useNavigate();
   const setCurrentDate = useDiaryStore((s) => s.setCurrentDate);
   const loadEntry = useDiaryStore((s) => s.loadEntry);
 
   useEffect(() => {
     listMonthInk(String(year), pad(month))
-      .then((map) => setEntries(map))
-      .catch(() => setEntries({}));
+      .then((map) => setInkTotals(map))
+      .catch(() => setInkTotals({}));
   }, [year, month]);
 
   const todayYmd = `${today.getFullYear()}-${pad(today.getMonth() + 1)}-${pad(today.getDate())}`;
@@ -31,7 +31,7 @@ export default function CalendarPage() {
       <CalendarGrid
         year={year}
         month={month}
-        entries={entries}
+        inkTotals={inkTotals}
         today={todayYmd}
         onSelect={(ymd) => {
           setCurrentDate(ymd);


### PR DESCRIPTION
## Summary
- support displaying either entry counts or ink totals in `CalendarGrid`
- render multiple dots for small counts or a proportional density bar for larger amounts
- highlight today's date and update `CalendarPage` to pass ink totals

## Testing
- `yarn lint`
- `yarn test` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1187/chrome-linux/headless_shell)*

------
https://chatgpt.com/codex/tasks/task_e_68be936ea1cc832ba6e615b27d1178ee