### PR TITLE
Queue S3 multipart completion POSTs offline

### DIFF
--- a/packages/web/src/service-worker.ts
+++ b/packages/web/src/service-worker.ts
@@ -105,8 +105,10 @@ self.addEventListener('fetch', (event) => {
   }
 
   if (
-    (req.method === 'PUT' || req.method === 'DELETE') &&
-    req.url.includes('amazonaws.com')
+    req.url.includes('amazonaws.com') &&
+    (req.method === 'PUT' ||
+      req.method === 'DELETE' ||
+      (req.method === 'POST' && req.url.includes('?uploadId=')))
   ) {
     event.respondWith(
       fetch(req.clone()).catch(async () => {
@@ -116,7 +118,7 @@ self.addEventListener('fetch', (event) => {
           },
         });
         let body: ArrayBuffer | undefined;
-        if (req.method === 'PUT') {
+        if (req.method === 'PUT' || req.method === 'POST') {
           body = await req.clone().arrayBuffer();
         }
         await db.add('requests', {


### PR DESCRIPTION
## Summary
- queue POST requests to S3 multipart upload completion URLs offline
- resend queued POSTs during background sync

## Testing
- `yarn test` *(fails: tests/diary.spec.ts, tests/offline.spec.ts, tests/routine.spec.ts, tests/theme.spec.ts, tests/weekly.spec.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68beb50c1184832bb8a5445945b10462