### PR TITLE
feat: add weekly lambda deployment flag

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -64,7 +64,7 @@ jobs:
         if: steps.test.outcome == 'success'
         run: |
           rm -f packages/infra/cdk-outputs.json
-          yarn workspace infra cdk deploy --all --require-approval never -c domain=$DOMAIN_NAME -c hostedZoneId=$HOSTED_ZONE_ID -c deployWeeklyReview=$ENABLE_WEEKLY_LAMBDA -c bedrockTokenCap=$BEDROCK_TOKEN_CAP -c bedrockCostCap=$BEDROCK_COST_CAP -c bedrockCostPer1k=$BEDROCK_COST_PER_1K -c aiProvider=$AI_PROVIDER -c openaiApiKey=$OPENAI_API_KEY -c geminiApiKey=$GEMINI_API_KEY --outputs-file cdk-outputs.json
+          yarn workspace infra cdk deploy --all --require-approval never -c domain=$DOMAIN_NAME -c hostedZoneId=$HOSTED_ZONE_ID -c enableWeeklyLambda=$ENABLE_WEEKLY_LAMBDA -c bedrockTokenCap=$BEDROCK_TOKEN_CAP -c bedrockCostCap=$BEDROCK_COST_CAP -c bedrockCostPer1k=$BEDROCK_COST_PER_1K -c aiProvider=$AI_PROVIDER -c openaiApiKey=$OPENAI_API_KEY -c geminiApiKey=$GEMINI_API_KEY --outputs-file cdk-outputs.json
 
       - name: Build web
         if: steps.test.outcome == 'success'

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -17,6 +17,7 @@ jobs:
       CDK_DEFAULT_REGION: ${{ vars.AWS_REGION }}
       DOMAIN_NAME: ${{ vars.DOMAIN_NAME }}
       HOSTED_ZONE_ID: ${{ vars.HOSTED_ZONE_ID }}
+      ENABLE_WEEKLY_LAMBDA: ${{ vars.ENABLE_WEEKLY_LAMBDA }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -55,4 +56,4 @@ jobs:
           fi
 
       - name: Destroy CDK stacks
-        run: yarn workspace infra cdk destroy --all --force -c domain=$DOMAIN_NAME -c hostedZoneId=$HOSTED_ZONE_ID
+        run: yarn workspace infra cdk destroy --all --force -c domain=$DOMAIN_NAME -c hostedZoneId=$HOSTED_ZONE_ID -c enableWeeklyLambda=$ENABLE_WEEKLY_LAMBDA

--- a/packages/infra/bin/app.ts
+++ b/packages/infra/bin/app.ts
@@ -20,8 +20,8 @@ const appStack = new AppStack(app, 'AppStack', {
 });
 
 const deployWeeklyReview =
-  app.node.tryGetContext('deployWeeklyReview') === 'true' ||
-  process.env.DEPLOY_WEEKLY_REVIEW === 'true';
+  app.node.tryGetContext('enableWeeklyLambda') === 'true' ||
+  process.env.ENABLE_WEEKLY_LAMBDA === 'true';
 
 if (deployWeeklyReview) {
   new WeeklyReviewStack(app, 'WeeklyReviewStack', {


### PR DESCRIPTION
## Summary
- add `enableWeeklyLambda` context flag to optionally deploy WeeklyReviewStack
- grant S3 and Secrets Manager access to weekly review lambda and expose function URL
- wire up `ENABLE_WEEKLY_LAMBDA` variable in CI workflows

## Testing
- `yarn test` *(fails: Playwright dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bec31b5518832b984a6ad543f4ae3d