### PR TITLE
feat: refresh cached entries after deletion

### DIFF
--- a/packages/web/src/components/Header.tsx
+++ b/packages/web/src/components/Header.tsx
@@ -27,7 +27,11 @@ export function Header() {
       void getCachedEntries(DEFAULT_DAYS).then((es) => setEntries(es));
     };
     window.addEventListener('entry-saved', refreshEntries);
-    return () => window.removeEventListener('entry-saved', refreshEntries);
+    window.addEventListener('entry-deleted', refreshEntries);
+    return () => {
+      window.removeEventListener('entry-saved', refreshEntries);
+      window.removeEventListener('entry-deleted', refreshEntries);
+    };
   }, []);
 
   useEffect(() => {

--- a/packages/web/src/main.tsx
+++ b/packages/web/src/main.tsx
@@ -17,4 +17,14 @@ if ('serviceWorker' in navigator) {
       })
       .catch((err) => console.error('Service worker registration failed', err));
   });
+
+  navigator.serviceWorker.addEventListener('message', (event) => {
+    if ((event.data as { type?: string; ymd?: string })?.type === 'entry-deleted') {
+      window.dispatchEvent(
+        new CustomEvent('entry-deleted', {
+          detail: { ymd: (event.data as { ymd?: string }).ymd },
+        })
+      );
+    }
+  });
 }


### PR DESCRIPTION
## Summary
- broadcast `entry-deleted` from service worker when entry removed
- forward service worker messages to window
- update header to refresh search cache on entry deletion

## Testing
- `yarn test` *(fails: Invalid subcommand. Try "info, run")*

------
https://chatgpt.com/codex/tasks/task_e_68bed117e69c832b867d149b63c8c44e