### PR TITLE
Add deploy and destroy CDK workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,10 +33,10 @@ jobs:
       - name: Build packages
         run: yarn workspaces foreach -pt --all run build
 
-      - name: Deploy CDK stack
-        run: yarn workspace infra cdk deploy AppStack --require-approval never --outputs-file cdk-outputs.json
+      - name: Deploy CDK stacks
+        run: yarn workspace infra cdk deploy EdgeStack AppStack --require-approval never --outputs-file cdk-outputs.json
 
-      - name: Upload web assets
+      - name: Sync dist to S3
         run: |
           WEB_BUCKET=$(jq -r '.AppStack.WebBucketName' packages/infra/cdk-outputs.json)
           aws s3 sync packages/web/dist s3://$WEB_BUCKET --delete

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Build packages
         run: yarn workspaces foreach -pt --all run build
 
-      - name: Read bucket names
+      - name: Read bucket names for cleanup
         run: |
           aws cloudformation describe-stacks --stack-name AppStack --query "Stacks[0].Outputs" > outputs.json
           WEB_BUCKET=$(jq -r '.[] | select(.OutputKey=="WebBucketName") | .OutputValue' outputs.json)
@@ -46,6 +46,6 @@ jobs:
           aws s3 rm "s3://$WEB_BUCKET" --recursive || true
           aws s3 rm "s3://$USER_BUCKET" --recursive || true
 
-      - name: Destroy stacks
+      - name: Destroy AppStack and EdgeStack
         run: yarn workspace infra cdk destroy AppStack EdgeStack --force --require-approval never
 


### PR DESCRIPTION
## Summary
- add GitHub Action to build web app, deploy CDK stacks, sync assets to S3 and invalidate CloudFront
- add teardown workflow to empty buckets and remove AppStack and EdgeStack

## Testing
- `yarn workspaces foreach -pt --all run lint`
- `yarn workspaces foreach -pt --all run test` *(fails: timeout errors in Playwright tests)*

------
https://chatgpt.com/codex/tasks/task_e_68bf22ab30dc832b8721e43b943f0573