### PR TITLE
feat(infra): flag weekly review scheduling

### DIFF
--- a/packages/infra/bin/app.ts
+++ b/packages/infra/bin/app.ts
@@ -26,10 +26,8 @@ const appStack = new AppStack(app, 'AppStack', {
 const enableWeeklyLambda =
   app.node.tryGetContext('enableWeeklyLambda') === 'true' ||
   process.env.ENABLE_WEEKLY_LAMBDA === 'true';
-
-if (enableWeeklyLambda) {
-  const weekly = new WeeklyReviewStack(app, 'WeeklyReviewStack', {
-    bucket: appStack.userBucket,
-  });
-  weekly.addDependency(appStack);
-}
+const weekly = new WeeklyReviewStack(app, 'WeeklyReviewStack', {
+  bucket: appStack.userBucket,
+  enableWeeklyLambda,
+});
+weekly.addDependency(appStack);


### PR DESCRIPTION
## Summary
- pass ENABLE_WEEKLY_LAMBDA flag when creating WeeklyReviewStack
- add optional EventBridge schedule and function URL output for debugging

## Testing
- `yarn workspace infra build`
- `yarn test` *(fails: browserType.launch: Executable doesn't exist ...)*

------
https://chatgpt.com/codex/tasks/task_e_68bf89997f74832b81ffca2995a4f85c