### PR TITLE
test: add weekly review e2e and ci

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,26 @@
+name: Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Run tests
+        run: |
+          npx playwright install --with-deps
+          yarn test
+

--- a/package.json
+++ b/package.json
@@ -6,6 +6,6 @@
   ],
   "scripts": {
     "build": "yarn workspaces foreach -pt --all run build",
-    "test": "yarn workspaces foreach -Av run test"
+    "test": "yarn workspace web test"
   }
 }

--- a/packages/web/tests/weekly.spec.ts
+++ b/packages/web/tests/weekly.spec.ts
@@ -1,14 +1,10 @@
 import { expect, test } from '@playwright/test';
 
-/**
- * E2E test exercising the weekly review page. It seeds a full week of
- * diary entries and ensures the UI reports the correct completion ratio,
- * current streak and improvement suggestion.
- */
+// E2E test exercising the weekly review page. It seeds a full week of diary
+// entries and ensures the UI reports the correct completion ratio, current
+// streak and improvement suggestion.
 
-/**
- * Helper returning the Monday at the start of the given week.
- */
+/** Helper returning the Monday at the start of the given week. */
 function startOfWeek(date: Date): Date {
   const d = new Date(date);
   const diff = (d.getDay() + 6) % 7; // Monday as start


### PR DESCRIPTION
## Summary
- add weekly review Playwright test
- run web tests via root script and GitHub Actions

## Testing
- `npx playwright install --with-deps` *(fails: Download failed: server returned code 403)*
- `yarn test` *(fails: browser executable doesn't exist)*

------
https://chatgpt.com/codex/tasks/task_e_68bf8a774a58832ba8c4de17635b8dc4