### PR TITLE
Restrict routine editing to current date

### DIFF
--- a/packages/web/src/pages/DatePage.tsx
+++ b/packages/web/src/pages/DatePage.tsx
@@ -238,6 +238,7 @@ export default function DatePage() {
       </header>
 
       <RoutineBar
+        editable={ymdStr === todayYmd}
         items={routineTicks}
         onChange={(items) => {
           setRoutineTicks(items);


### PR DESCRIPTION
## Summary
- Pass editable flag to RoutineBar based on whether viewing today
- Cover past and future routine item behavior in tests

## Testing
- `npx vitest run`
- `npx playwright test tests/routine.spec.ts` *(fails: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68bfbd8ab4f4832b8932802edbe831b0