### PR TITLE
Cache weekly summaries and reuse on reload

### DIFF
--- a/packages/web/src/lib/s3Client.test.ts
+++ b/packages/web/src/lib/s3Client.test.ts
@@ -46,10 +46,11 @@ vi.mock('@aws-sdk/client-s3', () => {
   return { S3Client, GetObjectCommand, PutObjectCommand, ListObjectsV2Command };
 });
 
-import { getSettings, __clearCachedSettings } from './s3Client';
+import { getSettings, __clearCachedSettings, getWeekly, __clearCachedWeekly } from './s3Client';
 
 beforeEach(() => {
   __clearCachedSettings();
+  __clearCachedWeekly();
   sendMock.mockReset();
 });
 
@@ -73,6 +74,30 @@ describe('getSettings', () => {
 
     expect(first).toEqual(settings);
     expect(second).toEqual(settings);
+    expect(sendMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('getWeekly', () => {
+  it('returns cached summary on 304', async () => {
+    const data = { aiSummary: 'Great week!' };
+    sendMock.mockResolvedValueOnce({
+      Body: Buffer.from(JSON.stringify(data)),
+      ETag: '"1"',
+    });
+    sendMock.mockImplementationOnce(() => {
+      const err = new Error('Not modified') as Error & {
+        $metadata?: { httpStatusCode: number };
+      };
+      err.$metadata = { httpStatusCode: 304 };
+      throw err;
+    });
+
+    const first = await getWeekly('2024', '01');
+    const second = await getWeekly('2024', '01');
+
+    expect(first?.aiSummary).toBe('Great week!');
+    expect(second).toEqual(first);
     expect(sendMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/web/tests/weekly.spec.ts
+++ b/packages/web/tests/weekly.spec.ts
@@ -78,3 +78,27 @@ test('weekly review shows habit stats, streaks and suggestions', async ({
   ).toBeVisible();
 });
 
+test('weekly summary persists across reloads', async ({ page }) => {
+  await page.route('**/entries/**', (route) =>
+    route.fulfill({ status: 404, body: '' })
+  );
+
+  let calls = 0;
+  await page.route('**/weekly/**', (route) => {
+    calls += 1;
+    if (calls === 1) {
+      return route.fulfill({
+        status: 200,
+        body: JSON.stringify({ aiSummary: 'Great week!' }),
+      });
+    }
+    return route.fulfill({ status: 304, body: '' });
+  });
+
+  await page.goto('/weekly');
+  await expect(page.getByText('Great week!')).toBeVisible();
+
+  await page.reload();
+  await expect(page.getByText('Great week!')).toBeVisible();
+});
+


### PR DESCRIPTION
## Summary
- cache weekly summaries locally and reuse them when the server responds with HTTP 304
- adjust tests to ensure cached summaries persist across reloads
- cover weekly summary caching logic in unit tests

## Testing
- `yarn test`
- `npx playwright test tests/weekly.spec.ts` *(fails: Executable doesn't exist at chromium headless shell)*

------
https://chatgpt.com/codex/tasks/task_e_68bfc1d66d98832ba86c7192545334b2