### PR TITLE
Add AES256 server-side encryption to uploads

### DIFF
--- a/packages/web/src/lib/s3Client.test.ts
+++ b/packages/web/src/lib/s3Client.test.ts
@@ -49,6 +49,8 @@ vi.mock('@aws-sdk/client-s3', () => {
 import {
   getSettings,
   putSettings,
+  putEntry,
+  putAttachment,
   __clearCachedSettings,
   getWeekly,
   __clearCachedWeekly,
@@ -137,5 +139,34 @@ describe('getConnectorStatus', () => {
     expect(first).toBe('added');
     expect(second).toBe('added');
     expect(sendMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('putAttachment', () => {
+  it('sets server-side encryption', async () => {
+    const file = { type: 'text/plain' } as unknown as File;
+    sendMock.mockResolvedValueOnce({});
+    await putAttachment('2024-01-01', 'uuid', 'txt', file);
+    const command = sendMock.mock.calls[0][0];
+    expect(command.input).toMatchObject({ ServerSideEncryption: 'AES256' });
+  });
+});
+
+describe('putEntry', () => {
+  it('sets server-side encryption', async () => {
+    sendMock.mockResolvedValueOnce({ ETag: '"1"' });
+    await putEntry('2024-01-01', '{}');
+    const command = sendMock.mock.calls[0][0];
+    expect(command.input).toMatchObject({ ServerSideEncryption: 'AES256' });
+  });
+});
+
+describe('putSettings', () => {
+  it('sets server-side encryption', async () => {
+    const settings = { theme: 'light', routineTemplate: [], timezone: 'UTC', e2ee: false };
+    sendMock.mockResolvedValueOnce({ ETag: '"1"' });
+    await putSettings(settings);
+    const command = sendMock.mock.calls[0][0];
+    expect(command.input).toMatchObject({ ServerSideEncryption: 'AES256' });
   });
 });

--- a/packages/web/src/lib/s3Client.ts
+++ b/packages/web/src/lib/s3Client.ts
@@ -108,6 +108,7 @@ export async function putAttachment(
       Key: key,
       Body: file,
       ContentType: file.type,
+      ServerSideEncryption: 'AES256',
     })
   );
 }
@@ -202,6 +203,7 @@ export async function putEntry(ymd: string, body: string): Promise<void> {
         Key: key,
         Body: normalized,
         ContentType: 'application/json',
+        ServerSideEncryption: 'AES256',
         ...(inkUsed !== undefined
           ? { Metadata: { ink: inkUsed.toString() } }
           : {}),
@@ -342,6 +344,7 @@ export async function putSettings(data: Settings): Promise<void> {
         Key: key,
         Body: JSON.stringify(data),
         ContentType: 'application/json',
+        ServerSideEncryption: 'AES256',
         ...(etag ? { IfMatch: etag } : {}),
       })
     );


### PR DESCRIPTION
## Summary
- encrypt attachments, entries, and settings uploads using S3 ServerSideEncryption `AES256`
- test that upload commands include the encryption flag

## Testing
- `yarn test`
- `npx eslint src/lib/s3Client.ts src/lib/s3Client.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68bfe86441c4832ba04ae43356b57864