### PR TITLE
Handle runtime config fetch errors

### DIFF
--- a/packages/web/src/runtime-config.test.ts
+++ b/packages/web/src/runtime-config.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect, vi } from 'vitest';
+
+describe('loadConfig', () => {
+  it('falls back to testMode config on fetch error', async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new Error('network'));
+    vi.stubGlobal('fetch', fetchMock);
+    const warnMock = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const { loadConfig } = await import('./runtime-config');
+    const cfg = await loadConfig();
+
+    expect(cfg.testMode).toBe(true);
+    expect(warnMock).toHaveBeenCalled();
+
+    warnMock.mockRestore();
+    vi.unstubAllGlobals();
+  });
+});

--- a/packages/web/src/runtime-config.ts
+++ b/packages/web/src/runtime-config.ts
@@ -12,9 +12,22 @@ let config: RuntimeConfig | null = null;
 
 export async function loadConfig(): Promise<RuntimeConfig> {
   if (config) return config;
-  const res = await fetch('/app-config.json');
-  if (!res.ok) throw new Error('Failed to load config');
-  config = (await res.json()) as RuntimeConfig;
+  try {
+    const res = await fetch('/app-config.json');
+    if (!res.ok) throw new Error('Failed to load config');
+    config = (await res.json()) as RuntimeConfig;
+  } catch (err) {
+    console.warn('Could not load config, falling back to test mode', err);
+    config = {
+      region: '',
+      userPoolId: '',
+      userPoolClientId: '',
+      identityPoolId: '',
+      hostedUiDomain: '',
+      entryBucket: '',
+      testMode: true,
+    };
+  }
   return config;
 }
 


### PR DESCRIPTION
## Summary
- prevent runtime-config from crashing when offline or fetch fails
- fall back to minimal test-mode config and warn the user
- cover test-mode fallback with a unit test

## Testing
- `yarn workspace web lint`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68c002afbb5c832bb7022898691c1f9e