### PR TITLE
docs: add instructions for setting GitHub variables and secrets

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -76,8 +76,18 @@ Configure the Lambda with environment variables according to the chosen AI provi
 | `BUCKET_NAME` | Target bucket for results |
 
 ## Repository variables and secrets
+All variables and secrets below must exist in your repository before any workflow runs.
 
-Set the following in GitHub before running workflows.
+Add them through either the GitHub web UI or the `gh` CLI:
+
+- **GitHub UI:** Navigate to *Settings > Secrets and variables > Actions* and add each entry under the **Variables** or **Secrets** tab.
+- **GitHub CLI:** for example,
+  ```bash
+  gh variable set AWS_ACCOUNT_ID --body <id>
+  gh secret set AWS_ROLE_ARN --body <arn>
+  ```
+
+See the GitHub docs for managing [actions variables](https://docs.github.com/actions/using-workflows/managing-variables) and [secrets](https://docs.github.com/actions/security-guides/encrypted-secrets).
 
 ### Variables
 


### PR DESCRIPTION
## Summary
- document how to create variables and secrets using the GitHub UI and `gh` CLI
- note that workflows require all variables and secrets to be present
- link to GitHub documentation for managing variables and secrets

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68c05813e7fc832ba0c8159b539e68f5